### PR TITLE
Add headers to sources to enable file browsing in IDEs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,9 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 	set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
 endif ()
 
-include_directories("${PROJECT_SOURCE_DIR}/include")
+set(include_dir "${PROJECT_SOURCE_DIR}/include")
+file(GLOB_RECURSE sqlpp_headers ${include_dir}/*.h)
+include_directories(${include_dir})
 add_subdirectory(tests)
 
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/sqlpp11" DESTINATION include)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 macro (build_and_run arg)
-	add_executable(${arg} ${arg}.cpp)
+	# Add headers to sources to enable file browsing in IDEs
+	add_executable(${arg} ${arg}.cpp ${sqlpp_headers})
 	add_test(${arg} ${arg})
 endmacro ()
 


### PR DESCRIPTION
By adding headers to sources of targets, CMake adds them to list of project files generated for IDEs.
This is non-intrusive trick, which does not affect targets compilation.
