### PR TITLE
Complete quoting for parameters of some CMake commands.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,8 @@ elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
 endif ()
 
 set(include_dir "${PROJECT_SOURCE_DIR}/include")
-file(GLOB_RECURSE sqlpp_headers ${include_dir}/*.h)
-include_directories(${include_dir})
+file(GLOB_RECURSE sqlpp_headers "${include_dir}/*.h")
+include_directories("${include_dir}")
 add_subdirectory(tests)
 add_subdirectory(test_constraints)
 

--- a/test_constraints/CMakeLists.txt
+++ b/test_constraints/CMakeLists.txt
@@ -1,26 +1,26 @@
-include_directories(${CMAKE_SOURCE_DIR}/tests)
+include_directories("${CMAKE_SOURCE_DIR}/tests")
 
 add_custom_target(test_sqlpp_constraints COMMAND true)
 
 function(test_constraint name pattern)
 
 	add_executable(
-		${name}
+		"${name}"
 		EXCLUDE_FROM_ALL
-		${name}.cpp
+		"${name}.cpp"
 		)
 
-	add_custom_command(OUTPUT ${name}.out
-				COMMAND ${CMAKE_MAKE_PROGRAM} ${name} > ${CMAKE_CURRENT_BINARY_DIR}/${name}.out 2>&1  || true
-				COMMAND grep ${pattern} ${CMAKE_CURRENT_BINARY_DIR}/${name}.out > /dev/null
-				DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${name}.cpp
+	add_custom_command(OUTPUT "${name}.out"
+				COMMAND "${CMAKE_MAKE_PROGRAM}" "${name}" > "${CMAKE_CURRENT_BINARY_DIR}/${name}.out" 2>&1  || true
+				COMMAND grep "${pattern}" "${CMAKE_CURRENT_BINARY_DIR}/${name}.out" > /dev/null
+				DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/${name}.cpp"
 				COMMENT "${name}"
-				)
+				VERBATIM)
 
-	add_custom_target(test_${name} DEPENDS ${name}.out COMMAND true)
+	add_custom_target("test_${name}" DEPENDS "${name}.out" COMMAND true)
 
 
-	add_dependencies(test_sqlpp_constraints test_${name})
+	add_dependencies(test_sqlpp_constraints "test_${name}")
 
 endfunction(test_constraint)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,9 +1,9 @@
 
 macro (build_and_run arg)
 	# Add headers to sources to enable file browsing in IDEs
-	include_directories(${CMAKE_BINARY_DIR}/tests)
-	add_executable(${arg} ${arg}.cpp ${sqlpp_headers} ${CMAKE_CURRENT_LIST_DIR}/Sample.h)
-	add_test(${arg} ${arg})
+	include_directories("${CMAKE_BINARY_DIR}/tests")
+	add_executable("${arg}" "${arg}.cpp" ${sqlpp_headers} "${CMAKE_CURRENT_LIST_DIR}/Sample.h")
+	add_test("${arg}" "${arg}")
 endmacro ()
 
 build_and_run(BooleanExpressionTest)
@@ -21,8 +21,7 @@ build_and_run(ResultTest)
 # if you want to use the generator, you can do something like this:
 #find_package(PythonInterp REQUIRED)
 #add_custom_command(
-#	OUTPUT ${CMAKE_CURRENT_LIST_DIR}/Sample.h 
-#	COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/scripts/ddl2cpp ${CMAKE_CURRENT_LIST_DIR}/sample.sql Sample test
-#	DEPENDS ${CMAKE_CURRENT_LIST_DIR}/sample.sql
-#	)
-
+#	OUTPUT "${CMAKE_CURRENT_LIST_DIR}/Sample.h"
+#	COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/scripts/ddl2cpp" "${CMAKE_CURRENT_LIST_DIR}/sample.sql" Sample test
+#	DEPENDS "${CMAKE_CURRENT_LIST_DIR}/sample.sql"
+#	VERBATIM)


### PR DESCRIPTION
[A wiki article pointed out](http://cmake.org/Wiki/CMake/Language_Syntax#CMake_splits_arguments_unless_you_use_quotation_marks_or_escapes.) that whitespace will only be preserved for parameters in CMake commands if passed strings will be appropriately quoted or escaped.

Quoting can be added so that more places should also handle file names correctly which contain semicolons eventually.
