### PR TITLE
feature/time_of_day

### DIFF
--- a/include/sqlpp11/data_types.h
+++ b/include/sqlpp11/data_types.h
@@ -32,6 +32,7 @@
 #include <sqlpp11/data_types/floating_point.h>
 #include <sqlpp11/data_types/text.h>
 #include <sqlpp11/data_types/day_point.h>
+#include <sqlpp11/data_types/time_of_day.h>
 #include <sqlpp11/data_types/time_point.h>
 #include <sqlpp11/data_types/no_value.h>
 

--- a/include/sqlpp11/data_types/time_of_day.h
+++ b/include/sqlpp11/data_types/time_of_day.h
@@ -24,34 +24,15 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SQLPP_CHRONO_H
-#define SQLPP_CHRONO_H
+#ifndef SQLPP_TIME_OF_DAY_H
+#define SQLPP_TIME_OF_DAY_H
 
-#include <date.h>
-
-namespace sqlpp
-{
-  namespace chrono
-  {
-    using days = std::chrono::duration<int, std::ratio_multiply<std::ratio<24>, std::chrono::hours::period>>;
-
-    using day_point = std::chrono::time_point<std::chrono::system_clock, days>;
-    using microsecond_point = std::chrono::time_point<std::chrono::system_clock, std::chrono::microseconds>;
-
-#if _MSC_FULL_VER >= 190023918
-    // MSVC Update 2 provides floor, ceil, round, abs in chrono (which is C++17 only...)
-    using ::std::chrono::floor;
-#else
-    using ::date::floor;
-#endif
-
-    template<typename T>
-    std::chrono::microseconds time_of_day(T t)
-    {
-      const auto dp = floor<days>(t);
-      return std::chrono::duration_cast<std::chrono::microseconds>(::date::make_time(t - dp).to_duration());
-    }
-  }
-}
+#include <sqlpp11/data_types/time_of_day/data_type.h>
+#include <sqlpp11/data_types/time_of_day/operand.h>
+#include <sqlpp11/data_types/time_of_day/wrap_operand.h>
+#include <sqlpp11/data_types/time_of_day/expression_operators.h>
+#include <sqlpp11/data_types/time_of_day/column_operators.h>
+#include <sqlpp11/data_types/time_of_day/parameter_value.h>
+#include <sqlpp11/data_types/time_of_day/result_field.h>
 
 #endif

--- a/include/sqlpp11/data_types/time_of_day/column_operators.h
+++ b/include/sqlpp11/data_types/time_of_day/column_operators.h
@@ -24,34 +24,21 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SQLPP_CHRONO_H
-#define SQLPP_CHRONO_H
+#ifndef SQLPP_TIME_OF_DAY_COLUMN_OPERATOR_H
+#define SQLPP_TIME_OF_DAY_COLUMN_OPERATOR_H
 
-#include <date.h>
+#include <sqlpp11/type_traits.h>
+#include <sqlpp11/assignment.h>
+#include <sqlpp11/data_types/time_of_day/data_type.h>
+#include <sqlpp11/data_types/column_operators.h>
 
 namespace sqlpp
 {
-  namespace chrono
+  template <typename Column>
+  struct column_operators<Column, time_of_day>
   {
-    using days = std::chrono::duration<int, std::ratio_multiply<std::ratio<24>, std::chrono::hours::period>>;
-
-    using day_point = std::chrono::time_point<std::chrono::system_clock, days>;
-    using microsecond_point = std::chrono::time_point<std::chrono::system_clock, std::chrono::microseconds>;
-
-#if _MSC_FULL_VER >= 190023918
-    // MSVC Update 2 provides floor, ceil, round, abs in chrono (which is C++17 only...)
-    using ::std::chrono::floor;
-#else
-    using ::date::floor;
-#endif
-
-    template<typename T>
-    std::chrono::microseconds time_of_day(T t)
-    {
-      const auto dp = floor<days>(t);
-      return std::chrono::duration_cast<std::chrono::microseconds>(::date::make_time(t - dp).to_duration());
-    }
-  }
+    template <typename T>
+    using _is_valid_operand = is_valid_operand<time_of_day, T>;
+  };
 }
-
 #endif

--- a/include/sqlpp11/data_types/time_of_day/data_type.h
+++ b/include/sqlpp11/data_types/time_of_day/data_type.h
@@ -24,34 +24,21 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SQLPP_CHRONO_H
-#define SQLPP_CHRONO_H
+#ifndef SQLPP_TIME_OF_DAY_DATA_TYPE_H
+#define SQLPP_TIME_OF_DAY_DATA_TYPE_H
 
-#include <date.h>
+#include <sqlpp11/chrono.h>
+#include <sqlpp11/type_traits.h>
 
 namespace sqlpp
 {
-  namespace chrono
+  struct time_of_day
   {
-    using days = std::chrono::duration<int, std::ratio_multiply<std::ratio<24>, std::chrono::hours::period>>;
+    using _traits = make_traits<time_of_day, tag::is_value_type>;
+    using _cpp_value_type = std::chrono::microseconds;
 
-    using day_point = std::chrono::time_point<std::chrono::system_clock, days>;
-    using microsecond_point = std::chrono::time_point<std::chrono::system_clock, std::chrono::microseconds>;
-
-#if _MSC_FULL_VER >= 190023918
-    // MSVC Update 2 provides floor, ceil, round, abs in chrono (which is C++17 only...)
-    using ::std::chrono::floor;
-#else
-    using ::date::floor;
-#endif
-
-    template<typename T>
-    std::chrono::microseconds time_of_day(T t)
-    {
-      const auto dp = floor<days>(t);
-      return std::chrono::duration_cast<std::chrono::microseconds>(::date::make_time(t - dp).to_duration());
-    }
-  }
+    template <typename T>
+    using _is_valid_operand = is_time_of_day_t<T>;
+  };
 }
-
 #endif

--- a/include/sqlpp11/data_types/time_of_day/expression_operators.h
+++ b/include/sqlpp11/data_types/time_of_day/expression_operators.h
@@ -24,34 +24,20 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SQLPP_CHRONO_H
-#define SQLPP_CHRONO_H
+#ifndef SQLPP_TIME_OF_DAY_EXPRESSION_OPERATORS_H
+#define SQLPP_TIME_OF_DAY_EXPRESSION_OPERATORS_H
 
-#include <date.h>
+#include <sqlpp11/expression_operators.h>
+#include <sqlpp11/basic_expression_operators.h>
+#include <sqlpp11/type_traits.h>
+#include <sqlpp11/data_types/time_of_day/data_type.h>
 
 namespace sqlpp
 {
-  namespace chrono
+  // time_of_day expression operators
+  template <typename Expression>
+  struct expression_operators<Expression, time_of_day> : public basic_expression_operators<Expression>
   {
-    using days = std::chrono::duration<int, std::ratio_multiply<std::ratio<24>, std::chrono::hours::period>>;
-
-    using day_point = std::chrono::time_point<std::chrono::system_clock, days>;
-    using microsecond_point = std::chrono::time_point<std::chrono::system_clock, std::chrono::microseconds>;
-
-#if _MSC_FULL_VER >= 190023918
-    // MSVC Update 2 provides floor, ceil, round, abs in chrono (which is C++17 only...)
-    using ::std::chrono::floor;
-#else
-    using ::date::floor;
-#endif
-
-    template<typename T>
-    std::chrono::microseconds time_of_day(T t)
-    {
-      const auto dp = floor<days>(t);
-      return std::chrono::duration_cast<std::chrono::microseconds>(::date::make_time(t - dp).to_duration());
-    }
-  }
+  };
 }
-
 #endif

--- a/include/sqlpp11/data_types/time_of_day/operand.h
+++ b/include/sqlpp11/data_types/time_of_day/operand.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2015-2015, Roland Bock
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *   Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *   Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SQLPP_TIME_OF_DAY_OPERAND_H
+#define SQLPP_TIME_OF_DAY_OPERAND_H
+
+#include <sqlpp11/chrono.h>
+#include <sqlpp11/type_traits.h>
+#include <sqlpp11/alias_operators.h>
+#include <sqlpp11/serializer.h>
+
+namespace sqlpp
+{
+  struct time_of_day;
+
+  template <typename Period>
+  struct time_of_day_operand : public alias_operators<time_of_day_operand<Period>>
+  {
+    using _traits = make_traits<time_of_day, tag::is_expression, tag::is_wrapped_value>;
+    using _nodes = detail::type_vector<>;
+    using _is_aggregate_expression = std::true_type;
+
+    using _value_t = std::chrono::microseconds;
+
+    time_of_day_operand() : _t{}
+    {
+    }
+
+    time_of_day_operand(_value_t t) : _t(t)
+    {
+    }
+
+    time_of_day_operand(const time_of_day_operand&) = default;
+    time_of_day_operand(time_of_day_operand&&) = default;
+    time_of_day_operand& operator=(const time_of_day_operand&) = default;
+    time_of_day_operand& operator=(time_of_day_operand&&) = default;
+    ~time_of_day_operand() = default;
+
+    bool _is_trivial() const
+    {
+      return std::chrono::operator==(_t, _value_t{});
+    }
+
+    _value_t _t;
+  };
+
+  template <typename Context, typename Period>
+  struct serializer_t<Context, time_of_day_operand<Period>>
+  {
+    using _serialize_check = consistent_t;
+    using Operand = time_of_day_operand<Period>;
+
+    static Context& _(const Operand& t, Context& context)
+    {
+      context << '\'' << ::date::make_time(t._t) << '\'';
+      return context;
+    }
+  };
+}
+#endif

--- a/include/sqlpp11/data_types/time_of_day/parameter_value.h
+++ b/include/sqlpp11/data_types/time_of_day/parameter_value.h
@@ -24,34 +24,30 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SQLPP_CHRONO_H
-#define SQLPP_CHRONO_H
+#ifndef SQLPP_TIME_OF_DAY_PARAMETER_VALUE_H
+#define SQLPP_TIME_OF_DAY_PARAMETER_VALUE_H
 
-#include <date.h>
+#include <sqlpp11/data_types/parameter_value.h>
+#include <sqlpp11/data_types/parameter_value_base.h>
+#include <sqlpp11/data_types/time_of_day/data_type.h>
+#include <sqlpp11/data_types/time_point/wrap_operand.h>
+#include <sqlpp11/data_types/time_point/operand.h>
+#include <sqlpp11/tvin.h>
 
 namespace sqlpp
 {
-  namespace chrono
+  template <>
+  struct parameter_value_t<time_of_day> : public parameter_value_base<time_of_day>
   {
-    using days = std::chrono::duration<int, std::ratio_multiply<std::ratio<24>, std::chrono::hours::period>>;
+    using base = parameter_value_base<time_of_day>;
+    using base::base;
+    using base::operator=;
 
-    using day_point = std::chrono::time_point<std::chrono::system_clock, days>;
-    using microsecond_point = std::chrono::time_point<std::chrono::system_clock, std::chrono::microseconds>;
-
-#if _MSC_FULL_VER >= 190023918
-    // MSVC Update 2 provides floor, ceil, round, abs in chrono (which is C++17 only...)
-    using ::std::chrono::floor;
-#else
-    using ::date::floor;
-#endif
-
-    template<typename T>
-    std::chrono::microseconds time_of_day(T t)
+    template <typename Target>
+    void _bind(Target& target, size_t index) const
     {
-      const auto dp = floor<days>(t);
-      return std::chrono::duration_cast<std::chrono::microseconds>(::date::make_time(t - dp).to_duration());
+      target._bind_time_of_day_parameter(index, &_value, _is_null);
     }
-  }
+  };
 }
-
 #endif

--- a/include/sqlpp11/data_types/time_of_day/result_field.h
+++ b/include/sqlpp11/data_types/time_of_day/result_field.h
@@ -64,8 +64,7 @@ namespace sqlpp
     }
     else
     {
-      const auto time = ::date::make_time(::sqlpp::chrono::floor<::date::days>(e.value() % std::chrono::duration<std::chrono::hours>(24)));
-      os << time;
+      os << ::date::make_time(e.value());
     }
     return os;
   }

--- a/include/sqlpp11/data_types/time_of_day/result_field.h
+++ b/include/sqlpp11/data_types/time_of_day/result_field.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2015-2015, Roland Bock
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *   Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *   Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SQLPP_TIME_OF_DAY_RESULT_FIELD_H
+#define SQLPP_TIME_OF_DAY_RESULT_FIELD_H
+
+#include <sqlpp11/chrono.h>
+#include <sqlpp11/basic_expression_operators.h>
+#include <sqlpp11/result_field.h>
+#include <sqlpp11/result_field_base.h>
+#include <sqlpp11/data_types/time_of_day/data_type.h>
+#include <sqlpp11/field_spec.h>
+#include <ostream>
+
+namespace sqlpp
+{
+  template <typename Db, typename NameType, bool CanBeNull, bool NullIsTrivialValue>
+  struct result_field_t<Db, field_spec_t<NameType, time_of_day, CanBeNull, NullIsTrivialValue>>
+      : public result_field_base<Db, field_spec_t<NameType, time_of_day, CanBeNull, NullIsTrivialValue>>
+  {
+    template <typename Target>
+    void _bind(Target& target, size_t i)
+    {
+      target._bind_time_of_day_result(i, &this->_value, &this->_is_null);
+    }
+
+    template <typename Target>
+    void _post_bind(Target& target, size_t i)
+    {
+      target._post_bind_time_of_day_result(i, &this->_value, &this->_is_null);
+    }
+  };
+
+  template <typename Db, typename NameType, bool CanBeNull, bool NullIsTrivialValue>
+  inline std::ostream& operator<<(
+      std::ostream& os, const result_field_t<Db, field_spec_t<NameType, time_of_day, CanBeNull, NullIsTrivialValue>>& e)
+  {
+    if (e.is_null() and not NullIsTrivialValue)
+    {
+      os << "NULL";
+    }
+    else
+    {
+      const auto time = ::date::make_time(::sqlpp::chrono::floor<::date::days>(e.value() % std::chrono::duration<std::chrono::hours>(24)));
+      os << time;
+    }
+    return os;
+  }
+}
+#endif

--- a/include/sqlpp11/data_types/time_of_day/wrap_operand.h
+++ b/include/sqlpp11/data_types/time_of_day/wrap_operand.h
@@ -24,34 +24,18 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef SQLPP_CHRONO_H
-#define SQLPP_CHRONO_H
+#ifndef SQLPP_TIME_OF_DAY_WRAP_OPERAND_H
+#define SQLPP_TIME_OF_DAY_WRAP_OPERAND_H
 
-#include <date.h>
+#include <sqlpp11/wrap_operand.h>
+#include <sqlpp11/data_types/time_of_day/operand.h>
 
 namespace sqlpp
 {
-  namespace chrono
+  template <typename Rep, typename Period>
+  struct wrap_operand<std::chrono::duration<Rep, Period>, void>
   {
-    using days = std::chrono::duration<int, std::ratio_multiply<std::ratio<24>, std::chrono::hours::period>>;
-
-    using day_point = std::chrono::time_point<std::chrono::system_clock, days>;
-    using microsecond_point = std::chrono::time_point<std::chrono::system_clock, std::chrono::microseconds>;
-
-#if _MSC_FULL_VER >= 190023918
-    // MSVC Update 2 provides floor, ceil, round, abs in chrono (which is C++17 only...)
-    using ::std::chrono::floor;
-#else
-    using ::date::floor;
-#endif
-
-    template<typename T>
-    std::chrono::microseconds time_of_day(T t)
-    {
-      const auto dp = floor<days>(t);
-      return std::chrono::duration_cast<std::chrono::microseconds>(::date::make_time(t - dp).to_duration());
-    }
-  }
+    using type = time_of_day_operand<std::chrono::duration<Rep, Period>>;
+  };
 }
-
 #endif

--- a/include/sqlpp11/type_traits.h
+++ b/include/sqlpp11/type_traits.h
@@ -83,6 +83,10 @@ namespace sqlpp
   template <typename T>
   using is_text_t = std::is_same<value_type_of<T>, text>;
 
+  struct time_of_day;
+  template <typename T>
+  using is_time_of_day_t = std::is_same<value_type_of<T>, time_of_day>;
+
   struct time_point;
   template <typename T>
   using is_time_point_t = std::is_same<value_type_of<T>, time_point>;

--- a/tests/DateTime.cpp
+++ b/tests/DateTime.cpp
@@ -58,21 +58,23 @@ int DateTime(int, char* [])
   db(insert_into(t).set(t.colDayPoint = floor<::sqlpp::chrono::days>(std::chrono::system_clock::now())));
   db(insert_into(t).set(t.colTimePoint = floor<::sqlpp::chrono::days>(std::chrono::system_clock::now())));
   db(insert_into(t).set(t.colTimePoint = std::chrono::system_clock::now()));
+  db(insert_into(t).set(t.colTimeOfDay = ::sqlpp::chrono::time_of_day(std::chrono::system_clock::now())));
 
   db(update(t)
          .set(t.colDayPoint = floor<::sqlpp::chrono::days>(std::chrono::system_clock::now()))
          .where(t.colDayPoint < std::chrono::system_clock::now()));
   db(update(t)
-         .set(t.colTimePoint = floor<::sqlpp::chrono::days>(std::chrono::system_clock::now()))
+         .set(t.colTimePoint = floor<::sqlpp::chrono::days>(std::chrono::system_clock::now()), t.colTimeOfDay = ::sqlpp::chrono::time_of_day(std::chrono::system_clock::now()))
          .where(t.colDayPoint < std::chrono::system_clock::now()));
   db(update(t)
-         .set(t.colTimePoint = std::chrono::system_clock::now())
+         .set(t.colTimePoint = std::chrono::system_clock::now(), t.colTimeOfDay = ::sqlpp::chrono::time_of_day(std::chrono::system_clock::now()))
          .where(t.colDayPoint < std::chrono::system_clock::now()));
 
   db(remove_from(t).where(t.colDayPoint == floor<::sqlpp::chrono::days>(std::chrono::system_clock::now())));
   db(remove_from(t).where(t.colDayPoint == std::chrono::system_clock::now()));
   db(remove_from(t).where(t.colTimePoint == floor<::sqlpp::chrono::days>(std::chrono::system_clock::now())));
   db(remove_from(t).where(t.colTimePoint == std::chrono::system_clock::now()));
+  db(remove_from(t).where(t.colTimeOfDay == ::sqlpp::chrono::time_of_day(std::chrono::system_clock::now())));
 
   return 0;
 }

--- a/tests/Sample.h
+++ b/tests/Sample.h
@@ -259,9 +259,32 @@ namespace test
       };
       using _traits = sqlpp::make_traits<sqlpp::time_point, sqlpp::tag::can_be_null>;
     };
+
+    struct ColTimeOfDay
+    {
+      struct _alias_t
+      {
+        static constexpr const char _literal[] = "col_time_of_day";
+        using _name_t = sqlpp::make_char_sequence<sizeof(_literal), _literal>;
+        template <typename T>
+        struct _member_t
+        {
+          T colTimeOfDay;
+          T& operator()()
+          {
+            return colTimeOfDay;
+          }
+          const T& operator()() const
+          {
+            return colTimeOfDay;
+          }
+        };
+      };
+      using _traits = sqlpp::make_traits<sqlpp::time_of_day, sqlpp::tag::can_be_null>;
+    };
   }
 
-  struct TabDateTime : sqlpp::table_t<TabDateTime, TabDateTime_::ColDayPoint, TabDateTime_::ColTimePoint>
+  struct TabDateTime : sqlpp::table_t<TabDateTime, TabDateTime_::ColDayPoint, TabDateTime_::ColTimePoint, TabDateTime_::ColTimeOfDay>
   {
     struct _alias_t
     {


### PR DESCRIPTION
This uses std::chrono::microseconds as the value type instead of sqlpp::chrono::microsecond_point. To convert a microsecond_point to microseconds, a helper function was added to sqlpp::chrono called time_of_day. Added tests to DateTime.cpp and a column definition to Sample.h.