### PR TITLE
Rogue underscore

### DIFF
--- a/scripts/ddl2cpp
+++ b/scripts/ddl2cpp
@@ -164,7 +164,7 @@ def ddlFunctionWord(string):
 ddlString = Or([QuotedString("'"), QuotedString("\"", escQuote='""'), QuotedString("`")])
 negativeSign = Literal('-')
 ddlNum = Combine(Optional(negativeSign) + Word(nums + "."))
-ddlTerm = Word(alphas, alphanums + "_$")
+ddlTerm = Word(alphanums + "_$")
 ddlName = Or([ddlTerm, ddlString])
 ddlArguments = "(" + delimitedList(Or([ddlString, ddlTerm, ddlNum])) + ")"
 ddlNotNull = Group(ddlWord("NOT") + ddlWord("NULL")).setResultsName("notNull")
@@ -181,7 +181,7 @@ ddlConstraint = Or([
         ])
 ddlColumn = Group(Optional(ddlConstraint).setResultsName("isConstraint") + OneOrMore(MatchFirst([ddlNotNull, ddlAutoValue, ddlDefaultValue, ddlFunctionWord("NOW"), ddlTerm, ddlNum, ddlColumnComment, ddlString, ddlArguments])))
 createTable = Group(ddlWord("CREATE") + ddlWord("TABLE") + ddlName.setResultsName("tableName") + "(" + Group(delimitedList(ddlColumn)).setResultsName("columns") + ")").setResultsName("create")
-
+#ddlString.setDebug(True) #uncomment to debug pyparsing
 
 ddl = ZeroOrMore(Suppress(SkipTo(createTable, False)) + createTable)
 

--- a/scripts/ddl2cpp
+++ b/scripts/ddl2cpp
@@ -161,16 +161,16 @@ def ddlWord(string):
 def ddlFunctionWord(string):
     return CaselessLiteral(string) + OneOrMore("(") + ZeroOrMore(" ") + OneOrMore(")")
 
-ddlString   = Or([QuotedString("'"), QuotedString("\"", escQuote='""'), QuotedString("`")])
+ddlString = Or([QuotedString("'"), QuotedString("\"", escQuote='""'), QuotedString("`")])
 negativeSign = Literal('-')
-ddlNum     = Combine(Optional(negativeSign) + Word(nums + "."))
-ddlTerm     = Word(alphas, alphanums + "_$")
-ddlName     = Or([ddlTerm, ddlString])
+ddlNum = Combine(Optional(negativeSign) + Word(nums + "."))
+ddlTerm = Word(alphas, alphanums + "_$")
+ddlName = Or([ddlTerm, ddlString])
 ddlArguments = "(" + delimitedList(Or([ddlString, ddlTerm, ddlNum])) + ")"
 ddlNotNull = Group(ddlWord("NOT") + ddlWord("NULL")).setResultsName("notNull")
 ddlDefaultValue = ddlWord("DEFAULT").setResultsName("hasDefaultValue")
 ddlAutoValue = ddlWord("AUTO_INCREMENT").setResultsName("hasAutoValue")
-ddlColumnComment  = Group(ddlWord("COMMENT") + ddlString).setResultsName("comment")
+ddlColumnComment = Group(ddlWord("COMMENT") + ddlString).setResultsName("comment")
 ddlConstraint = Or([
         ddlWord("CONSTRAINT"),
         ddlWord("PRIMARY"),
@@ -179,7 +179,7 @@ ddlConstraint = Or([
         ddlWord("INDEX"),
         ddlWord("UNIQUE"),
         ])
-ddlColumn   = Group(Optional(ddlConstraint).setResultsName("isConstraint") + OneOrMore(MatchFirst([ddlNotNull, ddlAutoValue, ddlDefaultValue, ddlFunctionWord("NOW"), ddlTerm, ddlNum, ddlColumnComment, ddlString, ddlArguments])))
+ddlColumn = Group(Optional(ddlConstraint).setResultsName("isConstraint") + OneOrMore(MatchFirst([ddlNotNull, ddlAutoValue, ddlDefaultValue, ddlFunctionWord("NOW"), ddlTerm, ddlNum, ddlColumnComment, ddlString, ddlArguments])))
 createTable = Group(ddlWord("CREATE") + ddlWord("TABLE") + ddlName.setResultsName("tableName") + "(" + Group(delimitedList(ddlColumn)).setResultsName("columns") + ")").setResultsName("create")
 
 


### PR DESCRIPTION
patch for #98 


the bug, it seems, was in this line (though I'll wait for test-runs) to declare it fixed :
```
-ddlTerm     = Word(alphas, alphanums + "_$")
+ddlTerm = Word(alphanums + "_$")

```
in pyparsing alphanums include alphas
other changes are just PEP compliance formatting

P.S. I didn't have HinnantDate lib installed system-wide, so I had to use 
`cmake -DHinnantDate_ROOT_DIR=/home/user/github/sqlpp11/date/ -DHinnantDate_INCLUDE_DIR=/home/user/github/sqlpp11/date/ .` 

because I have this directory structure for working with sqplp11
```
sqlpp11/
├── date
├── sqlpp11
└── sqlpp11-connector-mysql

```

Maybe we should add something about this to README  
