### PR TITLE
Find Hinnant date library in date/ subfolder

### DIFF
--- a/cmake/Modules/FindHinnantDate.cmake
+++ b/cmake/Modules/FindHinnantDate.cmake
@@ -53,7 +53,7 @@ set(HinnantDate_NOT_FOUND_MESSAGE "Could NOT find HinnantDate.
 Maybe you need to adjust the search paths or HinnantDate_ROOT_DIR.")
 
 find_file(HinnantDate_INCLUDE_FILE
-    date.h
+    date.h date/date.h
     HINTS ${HinnantDate_ROOT_DIR}
 )
 mark_as_advanced(HinnantDate_INCLUDE_FILE)


### PR DESCRIPTION
Horwards date library has grown to a few headers and I think it is cleaner to have them in a subfolder of the standard include path.
This is in line with my homebrew formula for date/sqlpp11: https://github.com/Marvin182/homebrew-zapfhahn/tree/master/Formula