### PR TITLE
Fix variadic template pack expansion failures on VS2017 RC

### DIFF
--- a/include/sqlpp11/having.h
+++ b/include/sqlpp11/having.h
@@ -237,7 +237,7 @@ namespace sqlpp
       //	  template <typename... T>
       //	  using _check = logic::all_t<is_expression_t<T>::value...>;
       template <typename... T>
-      struct _check : logic::all_t<is_expression_t<T>::value...>
+      struct _check : logic::all_t<is_expression_t<T>::value...>...
       {
       };
 

--- a/include/sqlpp11/statement.h
+++ b/include/sqlpp11/statement.h
@@ -121,8 +121,12 @@ namespace sqlpp
                _required_ctes::size::value == 0;
       }
 
+	  // work around for msvc bug:
+	  // error C3520 : 'Policies' : parameter pack must be expanded in this context
+	  using is_missing_policies_t_1 = logic::logic_helper<is_missing_t<Policies>::value...>;
+	  using is_missing_policies_t_2 = logic::logic_helper<(is_missing_t<Policies>::value && false)...>;
       using _value_type =
-          typename std::conditional<logic::none_t<is_missing_t<Policies>::value...>::value,
+          typename std::conditional<std::is_same<is_missing_policies_t_1, is_missing_policies_t_2>::value,
                                     value_type_of<_result_type_provider>,
                                     no_value_t  // if a required statement part is missing (e.g. columns in a select),
                                                 // then the statement cannot be used as a value


### PR DESCRIPTION
This pull request includes 2 workarounds to fix compile errors that occur on VS2017 RC but not VS2015. With this patch sqlpp11 compiles successfully with VS2017 RC.