### PR TITLE
Enhancements to result_t::iterator

### DIFF
--- a/include/sqlpp11/result.h
+++ b/include/sqlpp11/result.h
@@ -27,9 +27,17 @@
 #ifndef SQLPP_RESULT_H
 #define SQLPP_RESULT_H
 
-// FIXME: include for move?
+#include <iterator>
+#include <utility>
+
 namespace sqlpp
 {
+  template <typename>
+  struct iterator_category
+  {
+    using type = std::input_iterator_tag;
+  };
+
   template <typename DbResult, typename ResultRow>
   class result_t
   {
@@ -60,16 +68,22 @@ namespace sqlpp
     class iterator
     {
     public:
+      using iterator_category = typename iterator_category<DbResult>::type;
+      using value_type = result_row_t;
+      using pointer = const result_row_t*;
+      using reference = const result_row_t&;
+      using difference_type = std::ptrdiff_t;
+
       iterator(db_result_t& result, result_row_t& result_row) : _result(result), _result_row(result_row)
       {
       }
 
-      const result_row_t& operator*() const
+      reference operator*() const
       {
         return _result_row;
       }
 
-      const result_row_t* operator->() const
+      pointer operator->() const
       {
         return &_result_row;
       }
@@ -84,9 +98,17 @@ namespace sqlpp
         return not(operator==(rhs));
       }
 
-      void operator++()
+      iterator& operator++()
       {
         _result.next(_result_row);
+        return *this;
+      }
+
+      iterator operator++(int)
+      {
+        auto previous_it = *this;
+        _result.next(_result_row);
+        return previous_it;
       }
 
       db_result_t& _result;

--- a/tests/Select.cpp
+++ b/tests/Select.cpp
@@ -26,6 +26,7 @@
 #include "MockDb.h"
 #include "Sample.h"
 #include "is_regular.h"
+#include <algorithm>
 #include <iostream>
 #include <sqlpp11/alias_provider.h>
 #include <sqlpp11/connection.h>
@@ -52,6 +53,14 @@ struct to_cerr
   }
 };
 
+template <typename Row>
+void print_row(Row const& row)
+{
+  int64_t a = row.alpha;
+  const std::string b = row.beta;
+  std::cout << a << ", " << b << std::endl;
+}
+
 int Select(int, char* [])
 {
   MockDb db = {};
@@ -67,6 +76,13 @@ int Select(int, char* [])
   for (const auto& row : db(select(sqlpp::value(false).as(sqlpp::alias::a))))
   {
     std::cout << row.a << std::endl;
+  }
+
+  {
+    // using stl algorithms
+    auto rows = db(select(all_of(t)).from(t).unconditionally());
+    // nicer in C++14
+    std::for_each(rows.begin(), rows.end(), &print_row<decltype(*rows.begin())>);
   }
 
   for (const auto& row : db(select(all_of(t)).from(t).unconditionally()))


### PR DESCRIPTION
Hi Roland,

The first commit deals with the `iterator_traits` requirements we talked about in #142 .
About the second, I remember you said the iterator mutates the underlying sequence, therefore there could be no const overloads of `begin` and `end`.

I do think however, that the underlying mutation is not a part of the logical interface of the result object, but merely an implementation detail (part of the physical interface).

Furthermore, the following code already fails to compile:

```cpp
auto rows = db(select(all_of(t)).from(t).unconditionally());
for (auto& row : rows)
{
    // row is const here
    row.alpha = 4;
}
```

It would make sense (in my opinion), to be able to do `const auto rows = /* ... */` as well.

I'm looking forward to your inputs!