### PR TITLE
Added mediumint to ddl2cpp

### DIFF
--- a/scripts/ddl2cpp
+++ b/scripts/ddl2cpp
@@ -202,6 +202,7 @@ types = {
     'integer': 'integer',
     'int': 'integer',
     'serial': 'integer', # PostgreSQL
+    'mediumint' : 'integer',
     'bigint': 'bigint',
     'bigserial': 'bigint', # PostgreSQL
     'char': 'char_',


### PR DESCRIPTION
Really simple change to add mediumint to the list of recognized types in ddl2cpp script.