### PR TITLE
Add an option to set a transaction isolation level in start_transaction

### DIFF
--- a/connector_api/connection.h
+++ b/connector_api/connection.h
@@ -29,6 +29,7 @@
 
 #include <string>
 #include <sqlpp11/connection.h>
+#include <sqlpp11/transaction.h>
 #include <sqlpp11/database/char_result.h>  // You may use char result or bind result or both
 #include <sqlpp11/database/bind_result.h>  // to represent results of select and prepared select
 
@@ -130,7 +131,7 @@ namespace sqlpp
       }
 
       //! start transaction
-      void start_transaction();
+      void start_transaction(isolation_level isolation = isolation_level::undefined);
 
       //! commit transaction (or throw transaction if the transaction has been finished already)
       void commit_transaction();

--- a/include/sqlpp11/transaction.h
+++ b/include/sqlpp11/transaction.h
@@ -69,7 +69,7 @@ namespace sqlpp
 
     ~transaction_t()
     {
-      if (not _finished)
+      if (!_finished)
       {
         try
         {

--- a/include/sqlpp11/transaction.h
+++ b/include/sqlpp11/transaction.h
@@ -28,6 +28,7 @@
 #define SQLPP_TRANSACTION_H
 
 #include <stdexcept>
+#include <ciso646>
 
 namespace sqlpp
 {
@@ -69,7 +70,7 @@ namespace sqlpp
 
     ~transaction_t()
     {
-      if (!_finished)
+      if (not _finished)
       {
         try
         {

--- a/include/sqlpp11/transaction.h
+++ b/include/sqlpp11/transaction.h
@@ -100,16 +100,9 @@ namespace sqlpp
   };
 
   template <typename Db>
-  transaction_t<Db> start_transaction(Db& db, bool report_unfinished_transaction)
+  transaction_t<Db> start_transaction(Db& db, bool report_unfinished_transaction = report_auto_rollback)
   {
       return {db, report_unfinished_transaction};
-  }
-
-  template <typename Db>
-  transaction_t<Db> start_transaction(Db& db, bool report_unfinished_transaction = report_auto_rollback,
-                                      isolation_level isolation = isolation_level::undefined)
-  {
-    return {db, report_unfinished_transaction, isolation};
   }
 
   template <typename Db>

--- a/tests/MockDb.h
+++ b/tests/MockDb.h
@@ -28,6 +28,7 @@
 
 #include <iostream>
 #include <sqlpp11/connection.h>
+#include <sqlpp11/transaction.h>
 #include <sqlpp11/data_types/no_value.h>
 #include <sqlpp11/schema.h>
 #include <sqlpp11/serialize.h>
@@ -244,6 +245,22 @@ struct MockDbT : public sqlpp::connection
   {
     return {name};
   }
+
+  void start_transaction(sqlpp::isolation_level level)
+  {
+    _current_isolation_level = level;
+  }
+
+  void rollback_transaction(bool)
+  {}
+
+  void commit_transaction()
+  {}
+
+  void report_rollback_failure(std::string)
+  {}
+
+  sqlpp::isolation_level _current_isolation_level;
 };
 
 using MockDb = MockDbT<false>;

--- a/tests/MockDb.h
+++ b/tests/MockDb.h
@@ -35,6 +35,11 @@
 #include <sqlpp11/serializer_context.h>
 #include <sstream>
 
+// an object to store internal Mock flags and values to validate in tests
+struct InternalMockData {
+    sqlpp::isolation_level _last_isolation_level;
+};
+
 template <bool enforceNullResultTreatment>
 struct MockDbT : public sqlpp::connection
 {
@@ -248,7 +253,8 @@ struct MockDbT : public sqlpp::connection
 
   void start_transaction(sqlpp::isolation_level level)
   {
-    _current_isolation_level = level;
+    // store temporarily to verify the expected level was used in testcases
+    _mock_data._last_isolation_level = level;
   }
 
   void rollback_transaction(bool)
@@ -260,7 +266,7 @@ struct MockDbT : public sqlpp::connection
   void report_rollback_failure(std::string)
   {}
 
-  sqlpp::isolation_level _current_isolation_level;
+  InternalMockData _mock_data;
 };
 
 using MockDb = MockDbT<false>;

--- a/tests/Select.cpp
+++ b/tests/Select.cpp
@@ -183,7 +183,7 @@ int Select(int, char* [])
     for_each_field(row, to_cerr{});
   }
 
-  auto transaction = start_transaction(db, sqlpp::report_auto_rollback, sqlpp::isolation_level::read_committed);
+  auto transaction = start_transaction(db, sqlpp::isolation_level::read_committed);
   std::cout << (db._current_isolation_level == sqlpp::isolation_level::read_committed) << std::endl;
   
   return 0;

--- a/tests/Select.cpp
+++ b/tests/Select.cpp
@@ -184,7 +184,7 @@ int Select(int, char* [])
   }
 
   auto transaction = start_transaction(db, sqlpp::isolation_level::read_committed);
-  std::cout << (db._current_isolation_level == sqlpp::isolation_level::read_committed) << std::endl;
+  std::cout << (db._mock_data._last_isolation_level == sqlpp::isolation_level::read_committed) << std::endl;
   
   return 0;
 }

--- a/tests/Select.cpp
+++ b/tests/Select.cpp
@@ -183,5 +183,8 @@ int Select(int, char* [])
     for_each_field(row, to_cerr{});
   }
 
+  auto transaction = start_transaction(db, sqlpp::report_auto_rollback, sqlpp::isolation_level::read_committed);
+  std::cout << (db._current_isolation_level == sqlpp::isolation_level::read_committed) << std::endl;
+  
   return 0;
 }


### PR DESCRIPTION
This code lets a user select one of the four standardized transaction isolation levels when opening a transaction. Actual support dependes on the connectors, e.g. for SQLite only "serializable" and "read uncommitted" are meaningful.

I tried to implement the start_transaction() call in a way that should be backwards compatible with connectors not supporting the isolation_level parameter, but that makes for some possible confusion with the overloads of start_transaction.

For implementations see pull requests for the sqlite3 and postgresql connectors.