### PR TITLE
Fixed mising namespace comment on tablenames (to silence clang-tidy).

### DIFF
--- a/scripts/ddl2cpp
+++ b/scripts/ddl2cpp
@@ -318,7 +318,7 @@ for create in tableCreations:
             traitslist.append(NAMESPACE + '::tag::require_insert')
         print('      using _traits = ' + NAMESPACE + '::make_traits<' + ', '.join(traitslist) + '>;', file=header)
         print('    };', file=header)
-    print('  }', file=header)
+    print('  } // namespace ' + tableNamespace, file=header)
     print('', file=header)
 
     print('  struct ' + tableClass + ': ' + NAMESPACE + '::table_t<' + tableTemplateParameters + '>', file=header)


### PR DESCRIPTION
This fixes clang-tidy complaining about missing namespace closing comments