### PR TITLE
add missing <string> include in schema.h

### DIFF
--- a/include/sqlpp11/schema.h
+++ b/include/sqlpp11/schema.h
@@ -27,6 +27,8 @@
 #ifndef SQLPP_SCHEMA_H
 #define SQLPP_SCHEMA_H
 
+#include <string>
+
 #include <sqlpp11/type_traits.h>
 #include <sqlpp11/serializer.h>
 


### PR DESCRIPTION
Hello, I had a compiler error while building the conan package on macOS.

There is a missing string include in `sqlpp11/schema.h` that I've added.

The bug can be fixed by reordering includes in the client code too.