### PR TITLE
Allow digits 0-9 in include guards

### DIFF
--- a/scripts/ddl2cpp
+++ b/scripts/ddl2cpp
@@ -45,7 +45,7 @@ from pyparsing import CaselessLiteral, Literal, SkipTo, restOfLine, oneOf, ZeroO
 # HELPERS
 
 def get_include_guard_name(namespace, inputfile):
-  val = re.sub("[^A-Za-z]+", "_", namespace + '_' + os.path.basename(inputfile))
+  val = re.sub("[^A-Za-z0-9]+", "_", namespace + '_' + os.path.basename(inputfile))
   return val.upper()
 
 def identity_naming_func(s):


### PR DESCRIPTION
Without this change, headers generated for tables `foo0` and `foo1` in the same namespace have clashing include guards.