### PR TITLE
Install and export ddl2cpp script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,11 @@ install(TARGETS sqlpp11
         EXPORT Sqlpp11Targets
 )
 
+install(PROGRAMS "${PROJECT_SOURCE_DIR}/scripts/ddl2cpp"
+        RENAME sqlpp11-ddl2cpp
+        DESTINATION bin
+)
+
 include(CMakePackageConfigHelpers)
 
 write_basic_package_version_file(

--- a/cmake/Sqlpp11Config.cmake
+++ b/cmake/Sqlpp11Config.cmake
@@ -29,3 +29,17 @@ include(CMakeFindDependencyMacro)
 find_dependency(HinnantDate REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/Sqlpp11Targets.cmake")
+
+# Import "ddl2cpp" script
+if(TARGET sqlpp11::ddl2cpp)
+  message(FATAL_ERROR "Target sqlpp11::ddl2cpp already defined")
+endif()
+get_filename_component(sqlpp11_ddl2cpp_location "${CMAKE_CURRENT_LIST_DIR}/../../../bin/sqlpp11-ddl2cpp" REALPATH)
+if(NOT EXISTS "${sqlpp11_ddl2cpp_location}")
+  message(FATAL_ERROR "The imported target sqlpp11::ddl2cpp references the file '${sqlpp11_ddl2cpp_location}' but this file does not exists.")
+endif()
+add_executable(sqlpp11::ddl2cpp IMPORTED)
+set_target_properties(sqlpp11::ddl2cpp PROPERTIES
+  IMPORTED_LOCATION "${sqlpp11_ddl2cpp_location}"
+)
+unset(sqlpp11_ddl2cpp_location)


### PR DESCRIPTION
This patch install and export the ddl2cpp utility script as a CMake target.

Two remarks: 
* I've renamed, on install, the script to sqlpp11-ddl2cpp as I found the name not specific enough to avoid potential conflict. I've not renamed it in the sources to avoid breaking users that may rely on that in a cloned repo. Feel free to suggest another approach or another name.
* I didn't find a nicer way to export/import the associated target. I handled it by hand. Especially, I copied the checks generated by CMake for normal exported targets (Is the target already exported?, Does the script file exists?). I didn't find a way to make CMake export the utility scritp as a target without "building" it. If you have a solution I'll gladly fix that.