### PR TITLE
sqlite3: added real data type

### DIFF
--- a/scripts/ddl2cpp
+++ b/scripts/ddl2cpp
@@ -219,6 +219,7 @@ types = {
     'boolean': 'boolean',
     'double': 'floating_point',
     'float': 'floating_point',
+    'real': 'floating_point',
     'date': 'day_point',
     'datetime': 'time_point',
     'timestamp': 'time_point',


### PR DESCRIPTION
Added support for SQLite3's [REAL](https://www.sqlite.org/datatype3.html) data type 