### PR TITLE
Remove "MSVC 2017 is currently broken" message

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,6 @@ Branch / Compiler | clang-3.4,  gcc-4.9, Xcode-7   |  MSVC 2015/2017  | Test Cov
 master | [![Build Status](https://travis-ci.org/rbock/sqlpp11.svg?branch=master)](https://travis-ci.org/rbock/sqlpp11?branch=master) | [![Build status](https://ci.appveyor.com/api/projects/status/eid7mwqgavo0h61h/branch/master?svg=true)](https://ci.appveyor.com/project/rbock/sqlpp11/branch/master) | [![Coverage Status](https://coveralls.io/repos/rbock/sqlpp11/badge.svg?branch=master)](https://coveralls.io/r/rbock/sqlpp11?branch=master)
 develop | [![Build Status](https://travis-ci.org/rbock/sqlpp11.svg?branch=develop)](https://travis-ci.org/rbock/sqlpp11?branch=develop) | [![Build status](https://ci.appveyor.com/api/projects/status/eid7mwqgavo0h61h/branch/develop?svg=true)](https://ci.appveyor.com/project/rbock/sqlpp11/branch/develop) | [![Coverage Status](https://coveralls.io/repos/rbock/sqlpp11/badge.svg?branch=develop)](https://coveralls.io/r/rbock/sqlpp11?branch=develop)
 
-MSVC 2017 is currently broken, see
-   - https://github.com/rbock/sqlpp11/issues/181
-   - https://developercommunity.visualstudio.com/content/problem/95983/c-vs152-153-regression-in-variadic-template-argume.html
-
 Additional information available:
 ---------------------------------
 Past talks about sqlpp11 and some coding concepts used within the library:


### PR DESCRIPTION
Minor documentation cleanup.