### PR TITLE
Fixed transaction_t move constructor

### DIFF
--- a/include/sqlpp11/transaction.h
+++ b/include/sqlpp11/transaction.h
@@ -66,7 +66,12 @@ namespace sqlpp
     }
 
     transaction_t(const transaction_t&) = delete;
-    transaction_t(transaction_t&&) = default;
+    transaction_t(transaction_t&& other)
+        : _db(other._db), _report_unfinished_transaction(other._report_unfinished_transaction), _finished(other._finished)
+    {
+        other._finished = true;
+    }
+
     transaction_t& operator=(const transaction_t&) = delete;
     transaction_t& operator=(transaction_t&&) = delete;
 


### PR DESCRIPTION
the move constructor was implemented as =default
this leaves the _finished member untouched after the move and causes the destructor of the moved from object to rollback the transaction.