### PR TITLE
Basic expression operators support in alias

### DIFF
--- a/include/sqlpp11/alias_provider.h
+++ b/include/sqlpp11/alias_provider.h
@@ -29,9 +29,10 @@
 
 #include <type_traits>
 #include <sqlpp11/char_sequence.h>
+#include <sqlpp11/basic_expression_operators.h>
 
 #define SQLPP_ALIAS_PROVIDER(name)                                           \
-  struct name##_t                                                            \
+struct name##_t : sqlpp::basic_expression_operators<name##_t>                \
   {                                                                          \
     struct _alias_t                                                          \
     {                                                                        \


### PR DESCRIPTION
SQLPP_ALIAS_PROVIDER creates an alias with basic expression operators.