### PR TITLE
Add explicit greater condition.

### DIFF
--- a/include/sqlpp11/table.h
+++ b/include/sqlpp11/table.h
@@ -52,7 +52,7 @@ namespace sqlpp
     using _nodes = detail::type_vector<>;
     using _provided_tables = detail::type_set<Table>;
 
-    static_assert(sizeof...(ColumnSpec), "at least one column required per table");
+    static_assert(sizeof...(ColumnSpec) > 0, "at least one column required per table");
     using _required_insert_columns =
         typename detail::make_type_set_if<require_insert_t, column_t<Table, ColumnSpec>...>::type;
     using _column_tuple_t = std::tuple<column_t<Table, ColumnSpec>...>;


### PR DESCRIPTION
New VS2019 Preview (MSVC 19.20) shows following warning without this fix:
```
warning C4305: 'if': truncation from 'size_t' to 'bool'
```