### PR TITLE
cmake improvements and bugfix with unsigned fields

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ set(ConfigPackageLocation lib/cmake/Sqlpp11)
 install(EXPORT Sqlpp11Targets
   FILE
     Sqlpp11Targets.cmake
+  NAMESPACE Sqlpp11::
   DESTINATION
     ${ConfigPackageLocation}
 )

--- a/cmake/Modules/FindHinnantDate.cmake
+++ b/cmake/Modules/FindHinnantDate.cmake
@@ -75,7 +75,6 @@ if (HinnantDate_INCLUDE_FILE)
         get_filename_component(HinnantDate_INCLUDE_DIR "${HinnantDate_INCLUDE_FILE}" DIRECTORY) # remove filename
         get_filename_component(HinnantDate_INCLUDE_DIR "${HinnantDate_INCLUDE_DIR}" DIRECTORY) # remove date dir
         mark_as_advanced(HinnantDate_INCLUDE_DIR)
-        set(HinnantDate_ROOT_DIR "${HinnantDate_INCLUDE_DIR}")
         unset(HinnantDate_NOT_FOUND_MESSAGE)
 
         if(NOT TARGET HinnantDate::Date)

--- a/cmake/Sqlpp11Config.cmake
+++ b/cmake/Sqlpp11Config.cmake
@@ -31,15 +31,13 @@ find_dependency(HinnantDate REQUIRED)
 include("${CMAKE_CURRENT_LIST_DIR}/Sqlpp11Targets.cmake")
 
 # Import "ddl2cpp" script
-if(TARGET sqlpp11::ddl2cpp)
-  message(FATAL_ERROR "Target sqlpp11::ddl2cpp already defined")
+if(NOT TARGET Sqlpp11::ddl2cpp)
+  get_filename_component(sqlpp11_ddl2cpp_location "${CMAKE_CURRENT_LIST_DIR}/../../../bin/sqlpp11-ddl2cpp" REALPATH)
+  if(NOT EXISTS "${sqlpp11_ddl2cpp_location}")
+    message(FATAL_ERROR "The imported target Sqlpp11::ddl2cpp references the file '${sqlpp11_ddl2cpp_location}' but this file does not exists.")
+  endif()
+  add_executable(Sqlpp11::ddl2cpp IMPORTED)
+  set_target_properties(Sqlpp11::ddl2cpp PROPERTIES
+          IMPORTED_LOCATION "${sqlpp11_ddl2cpp_location}")
+  unset(sqlpp11_ddl2cpp_location)
 endif()
-get_filename_component(sqlpp11_ddl2cpp_location "${CMAKE_CURRENT_LIST_DIR}/../../../bin/sqlpp11-ddl2cpp" REALPATH)
-if(NOT EXISTS "${sqlpp11_ddl2cpp_location}")
-  message(FATAL_ERROR "The imported target sqlpp11::ddl2cpp references the file '${sqlpp11_ddl2cpp_location}' but this file does not exists.")
-endif()
-add_executable(sqlpp11::ddl2cpp IMPORTED)
-set_target_properties(sqlpp11::ddl2cpp PROPERTIES
-  IMPORTED_LOCATION "${sqlpp11_ddl2cpp_location}"
-)
-unset(sqlpp11_ddl2cpp_location)

--- a/include/sqlpp11/data_types/unsigned_integral/expression_operators.h
+++ b/include/sqlpp11/data_types/unsigned_integral/expression_operators.h
@@ -48,14 +48,14 @@ namespace sqlpp
   struct return_type_plus<L, R, binary_operand_check_t<L, is_unsigned_integral_t, R, is_numeric_t>>
   {
     using check = consistent_t;
-    using type = value_type_of<wrap_operand_t<R>>;
+    using type = plus_t<wrap_operand_t<L>, integral, wrap_operand_t<R>>;
   };
 
   template <typename L, typename R>
   struct return_type_minus<L, R, binary_operand_check_t<L, is_unsigned_integral_t, R, is_numeric_not_unsigned_t>>
   {
     using check = consistent_t;
-    using type = value_type_of<wrap_operand_t<R>>;
+    using type = minus_t<wrap_operand_t<L>, integral, wrap_operand_t<R>>;
   };
 
   template <typename L, typename R>
@@ -69,14 +69,14 @@ namespace sqlpp
   struct return_type_multiplies<L, R, binary_operand_check_t<L, is_unsigned_integral_t, R, is_numeric_t>>
   {
     using check = consistent_t;
-    using type = value_type_of<wrap_operand_t<R>>;
+    using type = multiplies_t<wrap_operand_t<L>, value_type_of<wrap_operand_t<R>>, wrap_operand_t<R>>;
   };
 
   template <typename L, typename R>
   struct return_type_divides<L, R, binary_operand_check_t<L, is_unsigned_integral_t, R, is_numeric_t>>
   {
     using check = consistent_t;
-    using type = value_type_of<wrap_operand_t<R>>;
+    using type = divides_t<wrap_operand_t<L>, wrap_operand_t<R>>;
   };
 
   template <typename L, typename R>


### PR DESCRIPTION
Hi, 
First of all, I would like to thank for this awesome library, and I have to suggest a few improvements and bugfixes.
1) add "Sqlpp11" namespace to CMake target
RATIONALE: This is conventional in modern CMake, to have namespace the same name as a package name. e.g.:
```cmake
find_package(Sqlpp11)
...
target_link_libraries(mylib PRIVATE
  Sqlpp11::Sqlpp11) 
```
It should be noted, that main "sqlpp11" target should be changed to "Sqlpp11" too. (but I didn't do this in this PR)
2) do not change HinnantDate_ROOT_DIR after a library is found
RATIONALE: Do not change constants provided for configuration, during configuration. It fails in more complicated projects, that has multiple subprojects that each searches for the same libraries.
3) Do not show error, if a target is already defined via find_package.
RATIONALE: same logic applies as in 2), and if a target is already defined, the best option is to do nothing.

Regarding the bug for unsigned field types, I had an issue in this SQL.
```cpp
  _db->run(sqlpp::update(playerAccount)
    .set(playerAccount.curProxyId = sessionInfo.proxyId,
      playerAccount.loginCount = playerAccount.loginCount + 1,
      ...)
   ...
```
"+ 1" simple didn't compile :) i find that when loginCount is signed int, then it works, so i applied same logic to unsigned expression operations as in signed ones, but I'm not very confident with this fix. :)