### PR TITLE
Use Python3 for test_scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ notifications:
 
 install:
   - g++ --version
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; brew install cmake; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install cmake; fi
   - cmake --version
   - git clone https://github.com/HowardHinnant/date
   - cd date

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ notifications:
 
 install:
   - g++ --version
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install cmake; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew upgrade cmake; fi
   - cmake --version
   - git clone https://github.com/HowardHinnant/date
   - cd date

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,8 @@ notifications:
 
 install:
   - g++ --version
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; brew install cmake; fi
   - cmake --version
-  - which cmake
-  - echo $PATH
   - git clone https://github.com/HowardHinnant/date
   - cd date
   - git checkout tags/v2.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
   - g++ --version
   - cmake --version
   - which cmake
+  - echo $PATH
   - git clone https://github.com/HowardHinnant/date
   - cd date
   - git checkout tags/v2.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ notifications:
 install:
   - g++ --version
   - cmake --version
+  - which cmake
   - git clone https://github.com/HowardHinnant/date
   - cd date
   - git checkout tags/v2.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 
-dist: trusty
+dist: xenial
 sudo: required
 
 compiler:

--- a/test_scripts/CMakeLists.txt
+++ b/test_scripts/CMakeLists.txt
@@ -22,11 +22,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-include(FindPythonInterp)
+include(FindPython3)
 
-if (${PYTHONINTERP_FOUND})
+if (${Python3_Interpreter_FOUND})
   execute_process(
-          COMMAND ${PYTHON_EXECUTABLE} -c "import pyparsing"
+          COMMAND ${Python3_EXECUTABLE} -c "import pyparsing"
 	                RESULT_VARIABLE PythonRESULT
 									OUTPUT_VARIABLE PythonOUTPUT
           ERROR_VARIABLE PythonERROR
@@ -39,21 +39,21 @@ if (${PYTHONINTERP_FOUND})
     message(STATUS "Pyparsing is installed: Enabling ddl2cpp tests.")
 
 		add_test(NAME sqlpp11.test.ddl2cpp.bad_will_fail
-		         COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../scripts/ddl2cpp" -fail-on-parse
+		         COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../scripts/ddl2cpp" -fail-on-parse
 						         "${CMAKE_CURRENT_LIST_DIR}/ddl2cpp_sample_bad.sql"
 										 "${CMAKE_CURRENT_BINARY_DIR}/fail"
 										 test)
 		set_tests_properties(sqlpp11.test.ddl2cpp.bad_will_fail PROPERTIES WILL_FAIL 1)
 
 		add_test(NAME sqlpp11.test.ddl2cpp.bad_has_parse_error
-		         COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../scripts/ddl2cpp" -fail-on-parse
+		         COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../scripts/ddl2cpp" -fail-on-parse
 						         "${CMAKE_CURRENT_LIST_DIR}/ddl2cpp_sample_bad.sql"
 										 "${CMAKE_CURRENT_BINARY_DIR}/fail"
 										 test)
 		set_tests_properties(sqlpp11.test.ddl2cpp.bad_has_parse_error PROPERTIES PASS_REGULAR_EXPRESSION "Parsing error,.*")
 
 		add_test(NAME sqlpp11.test.ddl2cpp.good_succeeds
-		         COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../scripts/ddl2cpp" -fail-on-parse
+		         COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../scripts/ddl2cpp" -fail-on-parse
 						         "${CMAKE_CURRENT_LIST_DIR}/ddl2cpp_sample_good.sql"
 										 "${CMAKE_CURRENT_BINARY_DIR}/fail"
 										 test)
@@ -67,7 +67,7 @@ if (${PYTHONINTERP_FOUND})
       endif()
       add_custom_command(
           OUTPUT "${sqlpp.test.generated.sample.include}.h"
-          COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../scripts/ddl2cpp"
+          COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../scripts/ddl2cpp"
                   ${use_identity_naming}
                   "${CMAKE_CURRENT_LIST_DIR}/ddl2cpp_sample_good.sql"
                   "${sqlpp.test.generated.sample.include}"


### PR DESCRIPTION
Update test_scripts to use Python3 instead of FindPythonInterp (deprecated since CMake 3.12). Ignore Python2 since its support's gonna dropped soon also.