### PR TITLE
Make sure find_package(Sqlpp11) can be done multiple times

### DIFF
--- a/cmake/Sqlpp11Config.cmake
+++ b/cmake/Sqlpp11Config.cmake
@@ -31,15 +31,14 @@ find_dependency(HinnantDate REQUIRED)
 include("${CMAKE_CURRENT_LIST_DIR}/Sqlpp11Targets.cmake")
 
 # Import "ddl2cpp" script
-if(TARGET sqlpp11::ddl2cpp)
-  message(FATAL_ERROR "Target sqlpp11::ddl2cpp already defined")
+if(NOT TARGET sqlpp11::ddl2cpp)
+  get_filename_component(sqlpp11_ddl2cpp_location "${CMAKE_CURRENT_LIST_DIR}/../../../bin/sqlpp11-ddl2cpp" REALPATH)
+  if(NOT EXISTS "${sqlpp11_ddl2cpp_location}")
+    message(FATAL_ERROR "The imported target sqlpp11::ddl2cpp references the file '${sqlpp11_ddl2cpp_location}' but this file does not exists.")
+  endif()
+  add_executable(sqlpp11::ddl2cpp IMPORTED)
+  set_target_properties(sqlpp11::ddl2cpp PROPERTIES
+    IMPORTED_LOCATION "${sqlpp11_ddl2cpp_location}"
+  )
+  unset(sqlpp11_ddl2cpp_location)
 endif()
-get_filename_component(sqlpp11_ddl2cpp_location "${CMAKE_CURRENT_LIST_DIR}/../../../bin/sqlpp11-ddl2cpp" REALPATH)
-if(NOT EXISTS "${sqlpp11_ddl2cpp_location}")
-  message(FATAL_ERROR "The imported target sqlpp11::ddl2cpp references the file '${sqlpp11_ddl2cpp_location}' but this file does not exists.")
-endif()
-add_executable(sqlpp11::ddl2cpp IMPORTED)
-set_target_properties(sqlpp11::ddl2cpp PROPERTIES
-  IMPORTED_LOCATION "${sqlpp11_ddl2cpp_location}"
-)
-unset(sqlpp11_ddl2cpp_location)


### PR DESCRIPTION
It is expected that CMake packages can be found multiple times without
errors. The target generated and defined by CMake, e.g. in a
*Targets.cmake file have a similar guard.