### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,19 @@ brew install marvin182/zapfhahn/sqlpp11
 
 Some connectors can be installed with the formula. See `brew info marvin182/zapfhahn/sqlpp11` for available options.
 
+__Build via vcpkg:__
+
+You can download and install sqlpp11 using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+   
+    ```bash
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install sqlpp11
+    ```
+    
+The sqlpp11 port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 Basic usage:
 -------------


### PR DESCRIPTION
`sqlpp11` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for sqlpp11 and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build sqlpp11, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, arm, uwp) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/sqlpp11/portfile.cmake). We try to keep the library maintained as close as possible to the original library.