### PR TITLE
Update vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,19 +169,20 @@ __Build via vcpkg:__
 
 You can download and install sqlpp11 using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
    
-    ```bash
-    git clone https://github.com/Microsoft/vcpkg.git
-    cd vcpkg
-    ./bootstrap-vcpkg.sh
-    ./vcpkg integrate install
-    vcpkg install sqlpp11
-    ```
+```bash
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh
+./vcpkg integrate install
+vcpkg install sqlpp11
+```
     
 The sqlpp11 port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
-The connector libraries such as sqlite3 and mysql are come with sqlpp11, which are named as [sqlpp11-connector-sqlite3](https://github.com/microsoft/vcpkg/tree/master/ports/sqlpp11-connector-sqlite3) and [sqlpp11-connector-mysql](https://github.com/microsoft/vcpkg/tree/master/ports/sqlpp11-connector-mysql).
+The following connector libraries for sqlpp11 are maintained as a separate package in vcpkg:
 
-Both of these two ports are maintained as separate packages in vcpkg now.
+  * [sqlpp11-connector-sqlite3](https://github.com/microsoft/vcpkg/tree/master/ports/sqlpp11-connector-sqlite3) 
+  * [sqlpp11-connector-mysql](https://github.com/microsoft/vcpkg/tree/master/ports/sqlpp11-connector-mysql)
 
 Basic usage:
 -------------

--- a/README.md
+++ b/README.md
@@ -179,6 +179,10 @@ You can download and install sqlpp11 using the [vcpkg](https://github.com/Micros
     
 The sqlpp11 port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
+The connector libraries such as sqlite3 and mysql are come with sqlpp11, which are named as [sqlpp11-connector-sqlite3](https://github.com/microsoft/vcpkg/tree/master/ports/sqlpp11-connector-sqlite3) and [sqlpp11-connector-mysql](https://github.com/microsoft/vcpkg/tree/master/ports/sqlpp11-connector-mysql).
+
+Both of these two ports are maintained as separate packages in vcpkg now.
+
 Basic usage:
 -------------
 


### PR DESCRIPTION
The connector libraries such as `sqlite3 `and `mysql `which can come with `sqlpp11`. 
They are named as `sqlpp11-connector-sqlite3` and `sqlpp11-connector-mysql` in vcpkg.

In order to make them more clearer to be used, I add these information to readme.

Related #313 
