### PR TITLE
Fix connection pool compilation error

### DIFF
--- a/include/sqlpp11/connection_pool.h
+++ b/include/sqlpp11/connection_pool.h
@@ -183,7 +183,7 @@ namespace sqlpp
 
       try
       {
-        auto c = std::unique_ptr<Connection>(new Connection(*(config.get())));
+        auto c = std::unique_ptr<Connection>(new Connection(config));
         return pool_connection<Connection_config, Reconnect_policy, Connection>(c, this);
       }
       catch (const sqlpp::exception& e)


### PR DESCRIPTION
Tiny fix for a error I got when playing round with the connection pool built in to sqlpp11.
It seems like the constructor for a connection might have changed since it was implemented.

I know connection pools are not really a supported feature, but It's better fixed than not :)