### PR TITLE
Add some MYSQL types to the ddl2cpp script

### DIFF
--- a/scripts/ddl2cpp
+++ b/scripts/ddl2cpp
@@ -271,6 +271,7 @@ types = {
     'float4': 'floating_point', # PostgreSQL
     'real': 'floating_point',
     'numeric': 'floating_point', # PostgreSQL
+    'decimal' : 'floating_point', # MYSQL
     'date': 'day_point',
     'datetime': 'time_point',
     'time': 'time_of_day',
@@ -282,6 +283,7 @@ types = {
     'timestamptz': 'time_point', # PostgreSQL
     'enum': 'text',  # MYSQL
     'set': 'text',  # MYSQL,
+    'longtext' : 'text', #MYSQL
     'json' : 'text', # PostgreSQL
     'jsonb' : 'text', # PostgreSQL
     'tinyint unsigned': 'tinyint_unsigned', #MYSQL


### PR DESCRIPTION
decimal and numeric are essentially the same.
The max size for longtext IS 4.3 GB. I do not know if it would fit in the text implementation at full size (because I haven't read it) but I imagine it would work for most users even if not. 