### PR TITLE
deps: fixed condition for fetching date::date

### DIFF
--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -23,7 +23,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-if(NOT USE_SYSTEM_DATE)
+if(NOT USE_SYSTEM_DATE AND NOT TARGET date::date)
     include(FetchContent)
 
     FetchContent_Declare(date


### PR DESCRIPTION
Here the issue with FetchContent for managing dependencies when using sqlpp11 as subproject.

Let's assume that we use libraries as `add_subdirectory ` in main project

```
...
set(BUILD_TZ_LIB ON CACHE BOOL "" FORCE)
set(USE_SYSTEM_TZ_DB ON CACHE BOOL "" FORCE)
set(COMPILE_WITH_C_LOCALE ON CACHE BOOL "" FORCE)
add_subdirectory(3rdparty/date EXCLUDE_FROM_ALL)

add_subdirectory(3rdparty/sqlpp11)
add_subdirectory(3rdparty/sqlpp11-connector-sqlite3)
...
```
By adding date using `add_subdirectory` we inject `date::date` target into superproject.
But this target is not honored and `sqlpp11` fetching dependency without any knowledge about it.
So we'll have one dependency and second which will be fetched from hard-coded tag.
That's not what we expecting to see.

Using introduced `USE_SYSTEM_DATE` build option will not help, because we have no installed development package.

To fix this issue we can check for already existed target `date::date` and not fetch dependency.
This also will work for `find_package(date REQUIRED)` case. If it'll be found, then it also provide `date::date` target and not fetch from remote.

@Leon0402 @kovdan01 Thoughts?

Same issue with any backends (I use sqlpp11-sqlite-connector) which unconditionally fetching `sqlpp11` as dependency without any clue that it already included in superproject.