### PR TITLE
Add missing includes

### DIFF
--- a/include/sqlpp11/mysql/connection.h
+++ b/include/sqlpp11/mysql/connection.h
@@ -28,6 +28,7 @@
 #define SQLPP_MYSQL_CONNECTION_H
 
 #include <sqlpp11/connection.h>
+#include <sqlpp11/exception.h>
 #include <sqlpp11/mysql/bind_result.h>
 #include <sqlpp11/mysql/char_result.h>
 #include <sqlpp11/mysql/connection_config.h>

--- a/include/sqlpp11/postgresql/result_field.h
+++ b/include/sqlpp11/postgresql/result_field.h
@@ -28,6 +28,7 @@
 #define SQLPP_POSTGRESQL_BLOB_RESULT_FIELD_H
 
 #include <sqlpp11/basic_expression_operators.h>
+#include <sqlpp11/exception.h>
 #include <sqlpp11/result_field.h>
 #include <sqlpp11/result_field_base.h>
 #include <sqlpp11/data_types/blob/data_type.h>

--- a/include/sqlpp11/sqlite3/prepared_statement.h
+++ b/include/sqlpp11/sqlite3/prepared_statement.h
@@ -35,6 +35,7 @@
 #include <date/date.h>
 
 #include <sqlpp11/chrono.h>
+#include <sqlpp11/exception.h>
 #include <sqlpp11/sqlite3/export.h>
 
 #include <sqlpp11/sqlite3/prepared_statement_handle.h>


### PR DESCRIPTION
Those headers use `throw sqlpp::exception` but do not include the relevant header.

I had stumbled over that in `include/sqlpp11/mysql/bind_result.h` since my project failed to build, but that is already fixed. This PR fixes some remaining places.