### PR TITLE
Support MySQL connect timeout option

### DIFF
--- a/include/sqlpp11/mysql/connection.h
+++ b/include/sqlpp11/mysql/connection.h
@@ -70,6 +70,12 @@ namespace sqlpp
 
       inline void connect(MYSQL* mysql, const connection_config& config)
       {
+        if (config.connect_timeout_seconds != 0 &&
+            mysql_options(mysql, MYSQL_OPT_CONNECT_TIMEOUT, &config.connect_timeout_seconds))
+        {
+          throw sqlpp::exception("MySQL: could not set option MYSQL_OPT_CONNECT_TIMEOUT");
+        }
+
         if (!mysql_real_connect(mysql, config.host.empty() ? nullptr : config.host.c_str(),
                                 config.user.empty() ? nullptr : config.user.c_str(),
                                 config.password.empty() ? nullptr : config.password.c_str(), nullptr, config.port,

--- a/include/sqlpp11/mysql/connection_config.h
+++ b/include/sqlpp11/mysql/connection_config.h
@@ -47,12 +47,13 @@ namespace sqlpp
       std::string charset = "utf8";
       bool auto_reconnect = true;
       bool debug = false;
+      unsigned int connect_timeout_seconds = 0;  // 0 = do not override MySQL library default
 
       bool operator==(const connection_config& other) const
       {
         return (other.host == host and other.user == user and other.password == password and
                 other.database == database and other.charset == charset and other.auto_reconnect == auto_reconnect and
-                other.debug == debug);
+                other.debug == debug and other.connect_timeout_seconds == connect_timeout_seconds);
       }
 
       bool operator!=(const connection_config& other) const

--- a/tests/mysql/usage/Sample.cpp
+++ b/tests/mysql/usage/Sample.cpp
@@ -43,6 +43,7 @@ int Sample(int, char*[])
   config->user = "root";
   config->database = "sqlpp_mysql";
   config->debug = true;
+  config->connect_timeout_seconds = 5;
   try
   {
     mysql::connection db(config);


### PR DESCRIPTION
This is a major requirement for production-ready software. If no connection timeout is configured, it can take an OS-specific amount of time before an exception is thrown, in case the database host cannot be reached. For me, a combination of Linux / AWS RDS took 2 minutes. The change works in that setup, using a value of 5 seconds. Could not test locally on macOS due to https://github.com/rbock/sqlpp11/issues/400.