### PR TITLE
add example code for `count(1)` in Functions.md

### DIFF
--- a/docs/Functions.md
+++ b/docs/Functions.md
@@ -35,6 +35,11 @@ for (const auto& row : db(select(tab.name, avg(tab.value))
 }
 ```
 
+Use `count(1)` for simply query row count:
+```C++
+unsigned long n = db(select(count(1)).from(tab).unconditionally()).front().count;
+``` 
+
 # Text Functions
 ## concat
 Just use the + operator :-)

--- a/docs/Functions.md
+++ b/docs/Functions.md
@@ -37,7 +37,7 @@ for (const auto& row : db(select(tab.name, avg(tab.value))
 
 Use `count(1)` for simply query row count:
 ```C++
-unsigned long n = db(select(count(1)).from(tab).unconditionally()).front().count;
+const int64_t n = db(select(count(1)).from(tab).unconditionally()).front().count;
 ``` 
 
 # Text Functions


### PR DESCRIPTION
Add an example in Functions.md to explain `count(1)`.

This SQL is tested (I'm developing a python module with pybind11 and sqlpp11, so I test it in my python module):
```
>>> db.count_all_ip_proxy()
MySQL debug: Executing: 'SELECT COUNT(1) AS count_ FROM tb_ip_proxy'
MySQL debug: Constructing result, using handle at 0x104fe7e50
MySQL debug: Accessing next row of handle at 0x104fe7e50
4920
>>>
```