### PR TITLE
Add errcode/sqlstate to postgres exception handling

### DIFF
--- a/include/sqlpp11/postgresql/exception.h
+++ b/include/sqlpp11/postgresql/exception.h
@@ -125,6 +125,30 @@ namespace sqlpp
       }
     };
 
+    /** Any error not covered by standard errors. 
+     * For example custom error code from a user
+     * defined pl/pgsql function
+     * 
+     */
+    class DLL_PUBLIC sql_user_error : public sql_error
+    {
+      std::string m_Code;
+    
+    public:
+      sql_user_error(std::string whatarg, std::string code) : sql_error(std::move(whatarg)), m_Code(std::move(code))
+      {        
+      }
+      sql_user_error(std::string whatarg, std::string query, std::string code) : sql_error(std::move(whatarg),std::move(query)), m_Code(std::move(code))
+      {        
+      }
+
+      /// The code so the code raised
+      const std::string& code() const noexcept
+      {
+        return m_Code;
+      }
+    };
+
     // TODO: should this be called statement_completion_unknown!?
     /// "Help, I don't know whether transaction was committed successfully!"
     /** Exception that might be thrown in rare cases where the connection to the

--- a/include/sqlpp11/postgresql/result.h
+++ b/include/sqlpp11/postgresql/result.h
@@ -273,6 +273,9 @@ namespace sqlpp
             if (strcmp(code, "P0003") == 0)
               throw plpgsql_too_many_rows(Err, Query);
             throw plpgsql_error(Err, Query);
+            break;
+          default:
+            throw sql_user_error(Err, Query, code);
         }
       throw sql_error(Err, Query);
     }

--- a/tests/scripts/CMakeLists.txt
+++ b/tests/scripts/CMakeLists.txt
@@ -39,21 +39,21 @@ if (${Python3_Interpreter_FOUND})
     message(STATUS "Pyparsing is installed: Enabling ddl2cpp tests.")
 
     add_test(NAME sqlpp11.scripts.ddl2cpp.bad_will_fail
-             COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../../scripts/ddl2cpp" -fail-on-parse
+             COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../../scripts/ddl2cpp"
                      "${CMAKE_CURRENT_LIST_DIR}/ddl2cpp_sample_bad.sql"
                      "${CMAKE_CURRENT_BINARY_DIR}/fail"
                      test)
     set_tests_properties(sqlpp11.scripts.ddl2cpp.bad_will_fail PROPERTIES WILL_FAIL 1)
 
     add_test(NAME sqlpp11.scripts.ddl2cpp.bad_has_parse_error
-             COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../../scripts/ddl2cpp" -fail-on-parse
+             COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../../scripts/ddl2cpp"
                      "${CMAKE_CURRENT_LIST_DIR}/ddl2cpp_sample_bad.sql"
                      "${CMAKE_CURRENT_BINARY_DIR}/fail"
                      test)
-    set_tests_properties(sqlpp11.scripts.ddl2cpp.bad_has_parse_error PROPERTIES PASS_REGULAR_EXPRESSION "Parsing error,.*")
+    set_tests_properties(sqlpp11.scripts.ddl2cpp.bad_has_parse_error PROPERTIES PASS_REGULAR_EXPRESSION "ERROR: Could not parse.*")
 
     add_test(NAME sqlpp11.scripts.ddl2cpp.good_succeeds
-             COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../../scripts/ddl2cpp" -fail-on-parse
+             COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../../scripts/ddl2cpp"
                      "${CMAKE_CURRENT_LIST_DIR}/ddl2cpp_sample_good.sql"
                      "${CMAKE_CURRENT_BINARY_DIR}/fail"
                      test)


### PR DESCRIPTION
While using the library (with postgresql) I realized the result class wasn't sending the error code with the exception. This seems fine for the well named exception but not an database using user defined error codes.

I've created a "sql_user_error" class that stores the code and added a default case to the ThrowSQLError and added a test to verify operation.

In addition the ddl2cpp test wouldn't succeed when I ran `make test`. It appears that the code was changed recently and the cmake file wasn't updated. I took the liberty of adjusting the cmake file so the tests would execute.


If you're curious about the particular use case the API I've created inserted data into a view and a trigger handles the primary data validation. It's a time series database so several different errors that could happen like bad names, data off interval, etc and parsing the message text at the API level would be problematic.