### PR TITLE
Proper MariaDB and MySQl findPackage support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ cmake_minimum_required(VERSION 3.14)
 project(sqlpp11 VERSION 0.1 LANGUAGES CXX)
 
 ### Project Wide Setup
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/)
 
 include(GNUInstallDirs)
 include(CTest)
@@ -136,10 +136,18 @@ endif()
 
 if(BUILD_MYSQL_CONNECTOR)
   install_component(NAME Sqlpp11MySQL TARGETS sqlpp11_mysql DIRECTORY mysql)
+
+  install(FILES ${PROJECT_SOURCE_DIR}/cmake/FindMySQL.cmake
+    DESTINATION ${SQLPP11_INSTALL_CMAKEDIR}
+  )
 endif()
 
 if(BUILD_MARIADB_CONNECTOR)
   install_component(NAME Sqlpp11MariaDB TARGETS sqlpp11_mariadb DIRECTORY mysql)
+
+  install(FILES ${PROJECT_SOURCE_DIR}/cmake/FindMariaDB.cmake
+    DESTINATION ${SQLPP11_INSTALL_CMAKEDIR}
+  )
 endif()
 
 if(BUILD_POSTGRESQL_CONNECTOR)

--- a/cmake/FindMariaDB.cmake
+++ b/cmake/FindMariaDB.cmake
@@ -1,35 +1,58 @@
-# FindMySQL.cmake
+# Copyright (c) 2016, Christian David
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#   Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+#   Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 
 if(DEFINED MSVC)
-        find_path(MySQL_INCLUDE_DIR
+        find_path(MariaDB_INCLUDE_DIR
             NAMES mariadb_version.h
             PATH_SUFFIXES include
         )
-        find_library(MySQL_LIBRARY
+        find_library(MariaDB_LIBRARY
             NAMES libmariadb
             PATH_SUFFIXES lib
         )
 else()
-        find_path(MySQL_INCLUDE_DIR
+        find_path(MariaDB_INCLUDE_DIR
             NAMES mariadb_version.h
             PATH_SUFFIXES mariadb mysql
         )
-        find_library(MySQL_LIBRARY NAMES mariadb)
+        find_library(MariaDB_LIBRARY NAMES mariadb)
 endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
-    MySQL
-    MySQL_INCLUDE_DIR
-    MySQL_LIBRARY
+    MariaDB
+    MariaDB_INCLUDE_DIR
+    MariaDB_LIBRARY
 )
 
-if(MySQL_FOUND AND NOT TARGET MySQL::MySQL)
-    add_library(MySQL::MySQL UNKNOWN IMPORTED)
-    target_include_directories(MySQL::MySQL INTERFACE "${MySQL_INCLUDE_DIR}")
-    set_target_properties(MySQL::MySQL PROPERTIES
-        IMPORTED_LOCATION "${MySQL_LIBRARY}"
+if(MariaDB_FOUND AND NOT TARGET MariaDB::MariaDB)
+    add_library(MariaDB::MariaDB UNKNOWN IMPORTED)
+    target_include_directories(MariaDB::MariaDB INTERFACE "${MariaDB_INCLUDE_DIR}")
+    set_target_properties(MariaDB::MariaDB PROPERTIES
+        IMPORTED_LOCATION "${MariaDB_LIBRARY}"
         IMPORTED_LINK_INTERFACE_LANGUAGES "C")
 endif()
 
-mark_as_advanced(MySQL_INCLUDE_DIR MySQL_LIBRARY)
+mark_as_advanced(MariaDB_INCLUDE_DIR MariaDB_LIBRARY)

--- a/cmake/FindMySQL.cmake
+++ b/cmake/FindMySQL.cmake
@@ -1,4 +1,27 @@
-# FindMySQL.cmake
+# Copyright (c) 2016, Christian David
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#   Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+#   Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
 
 if(DEFINED MSVC)
         set(SEARCH_PATHS

--- a/cmake/configs/Sqlpp11Config.cmake
+++ b/cmake/configs/Sqlpp11Config.cmake
@@ -23,6 +23,10 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+# Temporarly prepend CMAKE_MODULE_PATH with current directory to find helper scripts such as FindPackage scripts
+set(CMAKE_MODULE_PATH_save ${CMAKE_MODULE_PATH})
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+
 include(CMakeFindDependencyMacro)
 find_dependency(Threads)
 find_dependency(date REQUIRED)
@@ -61,3 +65,7 @@ if(NOT TARGET sqlpp11::ddl2cpp)
   )
   unset(sqlpp11_ddl2cpp_location)
 endif()
+
+# Resture module path 
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH_save})
+unset(CMAKE_MODULE_PATH_save)


### PR DESCRIPTION
This MR does the following things: 
- Install our findPackage Scripts as well and then also make them available when searching for sqlpp11 dependencies (they are by default only on the Module Path during our sqlpp11 check to not pollute global space and override any custom find Package script clients might provide)
- Make mariadb actually expose a mariaDB Target, which we were already using => This also fixes the warning "The package name passed to `find_package_handle_standard_args` ..." 

I installed all connectors and tried out the `examples/usage_find_packae` examples with all connectors enabled and linked to. It seemed to work. But to verify that it really works, it would be great if someone could check this with an actual example also using the connectors. Just to make sure all libs are found that are necessary for compiling