### PR TITLE
Added MariaDB keywords GENERATED and PERIOD

### DIFF
--- a/scripts/ddl2cpp
+++ b/scripts/ddl2cpp
@@ -217,6 +217,7 @@ ddlAutoKeywords = [
     "SMALLSERIAL",
     "SERIAL",
     "BIGSERIAL",
+    "GENERATED",
 ]
 ddlAutoValue = pp.Or(map(pp.CaselessLiteral, sorted(ddlAutoKeywords, reverse=True)))
 
@@ -244,6 +245,7 @@ ddlConstraintKeywords = [
     "INDEX",
     "UNIQUE",
     "CHECK",
+    "PERIOD",
 ]
 ddlConstraint = pp.Group(
     pp.Or(map(pp.CaselessLiteral, sorted(ddlConstraintKeywords, reverse=True)))

--- a/tests/scripts/ddl2cpp_sample_good.sql
+++ b/tests/scripts/ddl2cpp_sample_good.sql
@@ -30,8 +30,13 @@ CREATE TABLE tab_foo
 	_epsilon bigint,
 	`omega` double,
         some_number NUMERIC(314,15),
-        CONSTRAINT uc_delta UNIQUE (delta, _epsilon)
-);
+        CONSTRAINT uc_delta UNIQUE (delta, _epsilon),
+	
+	-- explicit column definition for System-Versioned table
+	rowStart TIMESTAMP(6) GENERATED ALWAYS AS ROW START,
+	rowEnd TIMESTAMP(6) GENERATED ALWAYS AS ROW END,
+	PERIOD FOR SYSTEM_TIME(rowStart, rowEnd)
+) WITH SYSTEM VERSIONING; -- enable System-Versioning for this table
 
 CREATE TABLE tab_bar
 (
@@ -39,4 +44,6 @@ CREATE TABLE tab_bar
 	beta varchar(255) NULL DEFAULT "",
 	gamma bool NOT NULL,
 	delta int
-);
+	
+	-- implicit column definition for System-Versioned table
+)WITH SYSTEM VERSIONING; -- enable System-Versioning  for this table


### PR DESCRIPTION
Both keywords are used for System Versioned tables.
GENERATED marks a column as auto generated.
PERIOD is ignored fro the script.