### PR TITLE
Update ddl2cpp script to ignore OR REPLACE CLAUSE

### DIFF
--- a/scripts/ddl2cpp
+++ b/scripts/ddl2cpp
@@ -198,7 +198,8 @@ ddlType = (
 )
 
 ddlUnsigned = pp.CaselessLiteral("UNSIGNED").setResultsName("isUnsigned")
-ddlWidth = ddlLeft + pp.Word(pp.nums) + ddlRight
+ddlDigits = "," + pp.Word(pp.nums)
+ddlWidth = ddlLeft + pp.Word(pp.nums) + pp.Optional(ddlDigits) + ddlRight
 ddlTimezone = (
     (pp.CaselessLiteral("with") | pp.CaselessLiteral("without"))
     + pp.CaselessLiteral("time")
@@ -363,6 +364,7 @@ def testTable():
     text = """
   CREATE TABLE "public"."dk" (
   "id" int8 NOT NULL DEFAULT nextval('dk_id_seq'::regclass),
+  "strange" NUMERIC(314, 15),
   "last_update" timestamp(6) DEFAULT now(),
    PRIMARY KEY (id)
 )

--- a/tests/scripts/ddl2cpp_sample_good.sql
+++ b/tests/scripts/ddl2cpp_sample_good.sql
@@ -29,6 +29,7 @@ CREATE TABLE tab_foo
 	delta varchar(255),
 	_epsilon bigint,
 	`omega` double,
+        some_number NUMERIC(314,15),
         CONSTRAINT uc_delta UNIQUE (delta, _epsilon)
 );
 
@@ -39,4 +40,3 @@ CREATE TABLE tab_bar
 	gamma bool NOT NULL,
 	delta int
 );
-


### PR DESCRIPTION
ddl2cpp parser failed if the table was created with CREATE OR REPLACE TABLE... type of instructions. This patch ignores the OR REPLACE clause.