### PR TITLE
Add support for "rationale" column type from pg_rational extension

### DIFF
--- a/scripts/ddl2cpp
+++ b/scripts/ddl2cpp
@@ -50,10 +50,12 @@ ddlOperator = pp.Or(
 
 ddlBracedExpression = pp.Forward()
 ddlFunctionCall = pp.Forward()
-ddlCast = ddlString + "::" + ddlTerm
+ddlCastEnd = "::" + ddlTerm
+ddlCast = ddlString + ddlCastEnd
 ddlExpression = pp.OneOrMore(
     ddlBracedExpression
     | ddlFunctionCall
+    | ddlCastEnd
     | ddlCast
     | ddlOperator
     | ddlString
@@ -128,6 +130,7 @@ ddlTextTypes = [
     "json",  # PostgreSQL
     "tinytext",  # MYSQL
     "mediumtext",  # MYSQL
+    "rational", # PostgreSQL pg_rationale extension
 ]
 
 ddlText = pp.Or(
@@ -366,6 +369,17 @@ def testConstraint():
         assert result.isConstraint
 
 
+def testRational():
+    for text in [
+        "pos RATIONAL NOT NULL DEFAULT nextval('rational_seq')::integer",
+     ]:
+        result = ddlColumn.parseString(text, parseAll=True)
+        column = result[0]
+        assert column.name == "pos"
+        assert column.type == "text"
+        assert column.notNull
+
+
 def testTable():
     text = """
   CREATE TABLE "public"."dk" (
@@ -391,6 +405,7 @@ def testParser():
     testDateTime()
     testColumn()
     testConstraint()
+    testRational()
     testTable()
 
 

--- a/tests/scripts/CMakeLists.txt
+++ b/tests/scripts/CMakeLists.txt
@@ -38,6 +38,11 @@ if (${Python3_Interpreter_FOUND})
   else()
     message(STATUS "Pyparsing is installed: Enabling ddl2cpp tests.")
 
+    add_test(NAME sqlpp11.scripts.ddl2cpp.parser
+             COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../../scripts/ddl2cpp"
+                     "--test"
+                     test)
+
     add_test(NAME sqlpp11.scripts.ddl2cpp.bad_will_fail
              COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../../scripts/ddl2cpp"
                      "${CMAKE_CURRENT_LIST_DIR}/ddl2cpp_sample_bad.sql"
@@ -81,4 +86,3 @@ if (${Python3_Interpreter_FOUND})
 
   endif()
 endif()
-


### PR DESCRIPTION
Implement DDL2CPP support for the [pg_rational](https://github.com/begriffs/pg_rational) extension for PostgreSQL.
The generated column type is string as the C++ standard is still missing runtime ratio arithmetic. 