### PR TITLE
Update ddl2cpp to handle constraints with argument list.

### DIFF
--- a/scripts/ddl2cpp
+++ b/scripts/ddl2cpp
@@ -364,6 +364,7 @@ def testConstraint():
     for text in [
         "CONSTRAINT unique_person UNIQUE (first_name, last_name)",
         "UNIQUE (id)",
+        "UNIQUE (first_name,last_name)"
     ]:
         result = ddlConstraint.parseString(text, parseAll=True)
         assert result.isConstraint

--- a/scripts/ddl2cpp
+++ b/scripts/ddl2cpp
@@ -52,6 +52,7 @@ ddlBracedExpression = pp.Forward()
 ddlFunctionCall = pp.Forward()
 ddlCastEnd = "::" + ddlTerm
 ddlCast = ddlString + ddlCastEnd
+ddlBracedArguments = pp.Forward()
 ddlExpression = pp.OneOrMore(
     ddlBracedExpression
     | ddlFunctionCall
@@ -61,8 +62,10 @@ ddlExpression = pp.OneOrMore(
     | ddlString
     | ddlTerm
     | ddlNumber
+    | ddlBracedArguments
 )
 
+ddlBracedArguments << ddlLeft + pp.delimitedList(ddlExpression) + ddlRight
 ddlBracedExpression << ddlLeft + ddlExpression + ddlRight
 
 ddlArguments = pp.Suppress(pp.Group(pp.delimitedList(ddlExpression)))


### PR DESCRIPTION
In the DDL files of the project I am currently working on, there are 'UNIQUE (col1, col2,...)' constraints. Those were not being understood by ddl2cpp. 

I've added a simple workaround, so that our DDL files can be parsed. Feel free to either merge it or close this PR, if you don't like the workaround.