### PR TITLE
Fix some issues when compiling with MSVC

### DIFF
--- a/cmake/FindMariaDB.cmake
+++ b/cmake/FindMariaDB.cmake
@@ -24,12 +24,18 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 if(DEFINED MSVC)
+    set(SEARCH_PATHS
+        "$ENV{ProgramFiles}/MariaDB/*"
+        "$ENV{ProgramFiles\(x86\)}/MariaDB/*"
+    )
     find_path(MariaDB_INCLUDE_DIR
         NAMES mariadb_version.h
+        PATHS ${SEARCH_PATHS}
         PATH_SUFFIXES include
     )
     find_library(MariaDB_LIBRARY
         NAMES libmariadb
+        PATHS ${SEARCH_PATHS}
         PATH_SUFFIXES lib
     )
 else()

--- a/include/sqlpp11/mysql/bind_result.h
+++ b/include/sqlpp11/mysql/bind_result.h
@@ -34,6 +34,10 @@
 #include <sqlpp11/exception.h>
 #include <sqlpp11/mysql/sqlpp_mysql.h>
 
+#ifdef _MSC_VER
+#include <iso646.h>
+#endif
+
 namespace sqlpp
 {
   namespace mysql

--- a/include/sqlpp11/postgresql/bind_result.h
+++ b/include/sqlpp11/postgresql/bind_result.h
@@ -39,6 +39,7 @@
 #include "detail/prepared_statement_handle.h"
 
 #ifdef _MSC_VER
+#include <iso646.h>
 #pragma warning(disable : 4800)  // int to bool
 #endif
 namespace sqlpp

--- a/include/sqlpp11/sqlite3/bind_result.h
+++ b/include/sqlpp11/sqlite3/bind_result.h
@@ -35,6 +35,7 @@
 #include <sqlpp11/sqlite3/prepared_statement_handle.h>
 
 #ifdef _MSC_VER
+#include <iso646.h>
 #pragma warning(push)
 #pragma warning(disable : 4251)
 #endif


### PR DESCRIPTION
- Fix `FindMariaDB.cmake` not finding include directories and use similar structure to `FindMySQL.cmake`
- Fix missing include for `iso646.h` when building for windows