### PR TITLE
Extend match expression for table names in ddl2cpp

### DIFF
--- a/scripts/ddl2cpp
+++ b/scripts/ddl2cpp
@@ -43,7 +43,7 @@ ddlString = (
     pp.QuotedString("'") | pp.QuotedString('"', escQuote='""') | pp.QuotedString("`")
 )
 ddlTerm = pp.Word(pp.alphas + "_", pp.alphanums + "_.$")
-ddlName = pp.Or([ddlTerm, ddlString, pp.Combine(ddlString + "." + ddlString)])
+ddlName = pp.Or([ddlTerm, ddlString, pp.Combine(ddlString + "." + ddlString), pp.Combine(ddlTerm + ddlString)])
 ddlOperator = pp.Or(
     map(pp.CaselessLiteral, ["+", "-", "*", "/", "<", "<=", ">", ">=", "=", "%", "DIV"])
 )


### PR DESCRIPTION
Using pg_dump, if the table is named after a special keyword (e.g. character), is dumped as public."character".
This commit extends the names expression to match those cases.