### PR TITLE
Add possibility to assign a std::string_view to a prepared statement parameter

### DIFF
--- a/include/sqlpp11/data_types/text/parameter_value.h
+++ b/include/sqlpp11/data_types/text/parameter_value.h
@@ -33,6 +33,10 @@
 #include <sqlpp11/data_types/text/wrap_operand.h>
 #include <sqlpp11/data_types/text/operand.h>
 
+#if __cplusplus >= 201703L
+#include <string_view>
+#endif
+
 namespace sqlpp
 {
   template <>
@@ -47,6 +51,22 @@ namespace sqlpp
     {
       target._bind_text_parameter(index, &_value, _is_null);
     }
+
+#if __cplusplus >= 201703L
+    parameter_value_base& operator=(const std::string_view& val)
+    {
+      _value = val;
+      _is_null = false;
+      return *this;
+    }
+
+    parameter_value_base& operator=(const char* val)
+    {
+      _value = val;
+      _is_null = false;
+      return *this;
+    }
+#endif
   };
 }  // namespace sqlpp
 #endif

--- a/tests/core/usage/Insert.cpp
+++ b/tests/core/usage/Insert.cpp
@@ -27,6 +27,9 @@
 #include "Sample.h"
 #include "is_regular.h"
 #include <iostream>
+#if __cplusplus >= 201703L
+#include <string_view>
+#endif
 #include <sqlpp11/functions.h>
 #include <sqlpp11/insert.h>
 
@@ -102,6 +105,15 @@ int Insert(int, char*[])
   prepared_insert.params.delta = sqlpp::value_or_null<sqlpp::integer>(sqlpp::null);
   prepared_insert.params.delta = sqlpp::value_or_null(17);
   db(prepared_insert);
+
+#if __cplusplus >= 201703L
+  auto prepared_insert_sv = db.prepare(insert_into(t).set(t.gamma = parameter(t.gamma), t.delta = parameter(t.delta), t.beta = parameter(t.beta)));
+  prepared_insert_sv.params.gamma = true;
+  prepared_insert_sv.params.delta = 17;
+  std::string_view sv = "string_view";
+  prepared_insert_sv.params.beta = sv;
+  db(prepared_insert_sv);
+#endif
 
   return 0;
 }


### PR DESCRIPTION
Make it possible to assign a std::string_view to a prepared statement.

See as example (I've added it also to the `Insert.cpp`):
```c++
auto prepared_insert_sv = db.prepare(insert_into(t).set(t.gamma = parameter(t.gamma), t.delta = parameter(t.delta), t.beta = parameter(t.beta)));
prepared_insert_sv.params.gamma = true;
prepared_insert_sv.params.delta = 17;
std::string_view sv = "string_view";
prepared_insert_sv.params.beta = sv;
db(prepared_insert_sv);
```