### PR TITLE
Const connection config

### DIFF
--- a/include/sqlpp11/postgresql/connection.h
+++ b/include/sqlpp11/postgresql/connection.h
@@ -182,7 +182,7 @@ namespace sqlpp
 
       // ctor / dtor
       connection();
-      connection(const std::shared_ptr<connection_config>& config);
+      connection(const std::shared_ptr<const connection_config>& config);
       ~connection();
       connection(const connection&) = delete;
       connection(connection&&);
@@ -190,7 +190,7 @@ namespace sqlpp
       connection& operator=(connection&&);
 
       // creates a connection handle and connects to database
-      void connectUsing(const std::shared_ptr<connection_config>& config) noexcept(false);
+      void connectUsing(const std::shared_ptr<const connection_config>& config) noexcept(false);
 
       // Select stmt (returns a result)
       template <typename Select>
@@ -391,7 +391,7 @@ namespace sqlpp
     {
     }
 
-    inline connection::connection(const std::shared_ptr<connection_config>& config)
+    inline connection::connection(const std::shared_ptr<const connection_config>& config)
         : _handle(new detail::connection_handle(config))
     {
     }
@@ -417,7 +417,7 @@ namespace sqlpp
       return *this;
     }
 
-    inline void connection::connectUsing(const std::shared_ptr<connection_config>& config) noexcept(false)
+    inline void connection::connectUsing(const std::shared_ptr<const connection_config>& config) noexcept(false)
     {
       this->_handle.reset(new detail::connection_handle(config));
     }

--- a/include/sqlpp11/postgresql/detail/connection_handle.h
+++ b/include/sqlpp11/postgresql/detail/connection_handle.h
@@ -60,11 +60,11 @@ namespace sqlpp
 
       struct DLL_LOCAL connection_handle
       {
-        std::shared_ptr<connection_config> config;
+        std::shared_ptr<const connection_config> config;
         std::unique_ptr<PGconn, void(*)(PGconn*)>  postgres;
         std::set<std::string> prepared_statement_names;
 
-        connection_handle(const std::shared_ptr<connection_config>& config);
+        connection_handle(const std::shared_ptr<const connection_config>& config);
         connection_handle(const connection_handle&) = delete;
         connection_handle(connection_handle&&) = default;
         connection_handle& operator=(const connection_handle&) = delete;
@@ -79,7 +79,7 @@ namespace sqlpp
         void deallocate_prepared_statement(const std::string& name);
       };
 
-      inline connection_handle::connection_handle(const std::shared_ptr<connection_config>& conf)
+      inline connection_handle::connection_handle(const std::shared_ptr<const connection_config>& conf)
           : config(conf), postgres{nullptr, handle_cleanup}
       {
 #ifdef SQLPP_DYNAMIC_LOADING

--- a/tests/postgresql/usage/BasicConstConfig.cpp
+++ b/tests/postgresql/usage/BasicConstConfig.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2017, Volker Aßmann
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <iostream>
+#include <memory>
+#include <stdexcept>
+
+#include <sqlpp11/postgresql/connection.h>
+#include <sqlpp11/postgresql/exception.h>
+#include <sqlpp11/sqlpp11.h>
+
+namespace sql = sqlpp::postgresql;
+int BasicConstConfig(int, char*[])
+{
+  const std::shared_ptr<const sql::connection_config> const_config = []()
+  {
+    auto config = std::make_shared<sql::connection_config>();
+    config->host = "localhost";
+    config->user = "unknown_user_must_fail";
+    return config;
+  }();
+
+  try
+  {
+    sql::connection db(const_config);
+
+    throw std::logic_error("should never reach this point");
+  }
+  catch (const sqlpp::postgresql::broken_connection& ex)
+  {
+    std::cout << "Got exception: '" << ex.what() << "'";
+    return 0;
+  }
+
+  return 1;
+}

--- a/tests/postgresql/usage/CMakeLists.txt
+++ b/tests/postgresql/usage/CMakeLists.txt
@@ -28,6 +28,7 @@ target_include_directories(sqlpp11_postgresql_testing INTERFACE ${CMAKE_CURRENT_
 
 set(test_files
     Basic.cpp
+    BasicConstConfig.cpp
     Blob.cpp
     Constructor.cpp
     Date.cpp


### PR DESCRIPTION
- The postgres connection does not change the connection_config thus passing it as const.
- Implies 'thread safety' when using the same config for multiple connections