### PR TITLE
Connection pools

### DIFF
--- a/connector_api/connection.h
+++ b/connector_api/connection.h
@@ -88,11 +88,11 @@ namespace sqlpp
     };
 
     // The base database-specific connection class. Non-pooled and pooled connection classes derive from it
-    class conn_base : public sqlpp::connection  // this inheritance helps with ADL for dynamic_select, for instance
+    class connection_base : public sqlpp::connection  // this inheritance helps with ADL for dynamic_select, for instance
     {
     public:
       // Base configuration
-      using _conn_base_t = conn_base;
+      using _connection_base_t = connection_base;
 
       // Type of configuration instances
       using _config_t = connection_config;
@@ -208,17 +208,17 @@ namespace sqlpp
 
       // The constructors are private because the base class instances are never created directly,
       // The constructors are called from the constructors of the derived classes
-      conn_base() = default;
-      conn_base(_handle_ptr_t&& handle) : _handle{std::move(handle)}
+      connection_base() = default;
+      connection_base(_handle_ptr_t&& handle) : _handle{std::move(handle)}
       {
       }
     };
 
     // Normal non-pooled connections.
-    using connection = sqlpp::conn_normal<conn_base>;
+    using connection = sqlpp::connection_normal<connection_base>;
 
     // Pooled connections that are created by the thread pool
-    using conn_pooled = sqlpp::conn_pooled<conn_base>;
+    using connection_pooled = sqlpp::connection_pooled<connection_base>;
   }  // namespace database
 }  // namespace sqlpp
 

--- a/connector_api/connection.h
+++ b/connector_api/connection.h
@@ -215,10 +215,10 @@ namespace sqlpp
     };
 
     // Normal non-pooled connections.
-    using connection = sqlpp::connection_normal<connection_base>;
+    using connection = sqlpp::normal_connection<connection_base>;
 
     // Pooled connections that are created by the thread pool
-    using connection_pooled = sqlpp::connection_pooled<connection_base>;
+    using pooled_connection = sqlpp::pooled_connection<connection_base>;
   }  // namespace database
 }  // namespace sqlpp
 

--- a/connector_api/connection_pool.h
+++ b/connector_api/connection_pool.h
@@ -34,6 +34,6 @@ namespace sqlpp
 {
   namespace database
   {
-    using connection_pool = sqlpp::connection_pool<connection_pooled>;
+    using connection_pool = sqlpp::connection_pool<pooled_connection>;
   }  // namespace database
 } // namespace sqlpp

--- a/connector_api/connection_pool.h
+++ b/connector_api/connection_pool.h
@@ -1,0 +1,39 @@
+#pragma once
+
+/*
+Copyright (c) 2017 - 2018, Roland Bock
+Copyright (c) 2023, Vesselin Atanasov
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this
+   list of conditions and the following disclaimer in the documentation and/or
+   other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <sqlpp11/connection_pool.h>
+#include <sqlpp11/database/connection.h>
+
+namespace sqlpp
+{
+  namespace database
+  {
+    using connection_pool = sqlpp::connection_pool<conn_pooled>;
+  }  // namespace database
+} // namespace sqlpp

--- a/connector_api/connection_pool.h
+++ b/connector_api/connection_pool.h
@@ -34,6 +34,6 @@ namespace sqlpp
 {
   namespace database
   {
-    using connection_pool = sqlpp::connection_pool<conn_pooled>;
+    using connection_pool = sqlpp::connection_pool<connection_pooled>;
   }  // namespace database
 } // namespace sqlpp

--- a/include/sqlpp11/connection.h
+++ b/include/sqlpp11/connection.h
@@ -38,120 +38,120 @@ namespace sqlpp
   };
 
   // Normal (non-pooled) connection
-  template<typename ConnBase>
-  class conn_normal : public ConnBase
+  template<typename ConnectionBase>
+  class connection_normal : public ConnectionBase
   {
   public:
-    using _config_t = typename ConnBase::_config_t;
-    using _config_ptr_t = typename ConnBase::_config_ptr_t;
+    using _config_t = typename ConnectionBase::_config_t;
+    using _config_ptr_t = typename ConnectionBase::_config_ptr_t;
 
     // Constructors
-    conn_normal() = default;
-    conn_normal(const _config_t& config);
-    conn_normal(const _config_ptr_t& config);
-    conn_normal(const conn_normal&) = delete;
-    conn_normal(conn_normal&&) = default;
+    connection_normal() = default;
+    connection_normal(const _config_t& config);
+    connection_normal(const _config_ptr_t& config);
+    connection_normal(const connection_normal&) = delete;
+    connection_normal(connection_normal&&) = default;
 
     // Assigment operators
-    conn_normal& operator=(const conn_normal&) = delete;
-    conn_normal& operator=(conn_normal&&) = default;
+    connection_normal& operator=(const connection_normal&) = delete;
+    connection_normal& operator=(connection_normal&&) = default;
 
     // creates a connection handle and connects to database
     void connectUsing(const _config_ptr_t& config) noexcept(false);
 
   private:
-    using _handle_t = typename ConnBase::_handle_t;
+    using _handle_t = typename ConnectionBase::_handle_t;
   };
 
-  template<typename ConnBase>
-  conn_normal<ConnBase>::conn_normal(const _config_t& config) :
-    conn_normal{std::make_shared<_config_t>(config)}
+  template<typename ConnectionBase>
+  connection_normal<ConnectionBase>::connection_normal(const _config_t& config) :
+    connection_normal{std::make_shared<_config_t>(config)}
   {
   }
 
-  template<typename ConnBase>
-  conn_normal<ConnBase>::conn_normal(const _config_ptr_t& config) :
-    ConnBase{std::make_unique<_handle_t>(config)}
+  template<typename ConnectionBase>
+  connection_normal<ConnectionBase>::connection_normal(const _config_ptr_t& config) :
+    ConnectionBase{std::make_unique<_handle_t>(config)}
   {
   }
 
-  template<typename ConnBase>
-  void conn_normal<ConnBase>::connectUsing(const _config_ptr_t& config) noexcept(false)
+  template<typename ConnectionBase>
+  void connection_normal<ConnectionBase>::connectUsing(const _config_ptr_t& config) noexcept(false)
   {
-    ConnBase::_handle = std::make_unique<_handle_t>(config);
+    ConnectionBase::_handle = std::make_unique<_handle_t>(config);
   }
 
   // Forward declaration
-  template<typename ConnBase>
+  template<typename ConnectionBase>
   class connection_pool;
 
   // Pooled connection
-  template<typename ConnBase>
-  class conn_pooled : public ConnBase
+  template<typename ConnectionBase>
+  class connection_pooled : public ConnectionBase
   {
-    friend class connection_pool<ConnBase>::pool_core;
+    friend class connection_pool<ConnectionBase>::pool_core;
 
   public:
-    using _config_ptr_t = typename ConnBase::_config_ptr_t;
-    using _handle_t = typename ConnBase::_handle_t;
-    using _handle_ptr_t = typename ConnBase::_handle_ptr_t;
-    using _pool_core_ptr_t = std::shared_ptr<typename connection_pool<ConnBase>::pool_core>;
+    using _config_ptr_t = typename ConnectionBase::_config_ptr_t;
+    using _handle_t = typename ConnectionBase::_handle_t;
+    using _handle_ptr_t = typename ConnectionBase::_handle_ptr_t;
+    using _pool_core_ptr_t = std::shared_ptr<typename connection_pool<ConnectionBase>::pool_core>;
 
     // Copy/Move constructors
-    conn_pooled(const conn_pooled&) = delete;
-    conn_pooled(conn_pooled&& other) = default;
-    ~conn_pooled();
+    connection_pooled(const connection_pooled&) = delete;
+    connection_pooled(connection_pooled&& other) = default;
+    ~connection_pooled();
 
     // Assigment operators
-    conn_pooled& operator=(const conn_pooled&) = delete;
-    conn_pooled& operator=(conn_pooled&& other);
+    connection_pooled& operator=(const connection_pooled&) = delete;
+    connection_pooled& operator=(connection_pooled&& other);
 
   private:
     _pool_core_ptr_t _pool_core;
 
     // Constructors used by the connection pool
-    conn_pooled(_handle_ptr_t&& handle, _pool_core_ptr_t pool_core);
-    conn_pooled(const _config_ptr_t& config, _pool_core_ptr_t pool_core);
+    connection_pooled(_handle_ptr_t&& handle, _pool_core_ptr_t pool_core);
+    connection_pooled(const _config_ptr_t& config, _pool_core_ptr_t pool_core);
 
     void conn_release();
   };
 
-  template<typename ConnBase>
-  conn_pooled<ConnBase>::~conn_pooled()
+  template<typename ConnectionBase>
+  connection_pooled<ConnectionBase>::~connection_pooled()
   {
     conn_release();
   }
 
-  template<typename ConnBase>
-  conn_pooled<ConnBase>& conn_pooled<ConnBase>::operator=(conn_pooled&& other)
+  template<typename ConnectionBase>
+  connection_pooled<ConnectionBase>& connection_pooled<ConnectionBase>::operator=(connection_pooled&& other)
   {
     if (this != &other) {
       conn_release();
-      static_cast<ConnBase&>(*this) = std::move(static_cast<ConnBase&>(other));
+      static_cast<ConnectionBase&>(*this) = std::move(static_cast<ConnectionBase&>(other));
       _pool_core = std::move(other._pool_core);
     }
     return *this;
   }
 
-  template<typename ConnBase>
-  conn_pooled<ConnBase>::conn_pooled(_handle_ptr_t&& handle, _pool_core_ptr_t pool_core) :
-    ConnBase{std::move(handle)},
+  template<typename ConnectionBase>
+  connection_pooled<ConnectionBase>::connection_pooled(_handle_ptr_t&& handle, _pool_core_ptr_t pool_core) :
+    ConnectionBase{std::move(handle)},
     _pool_core{pool_core}
   {
   }
 
-  template<typename ConnBase>
-  conn_pooled<ConnBase>::conn_pooled(const _config_ptr_t& config, _pool_core_ptr_t pool_core) :
-    ConnBase{std::make_unique<_handle_t>(config)},
+  template<typename ConnectionBase>
+  connection_pooled<ConnectionBase>::connection_pooled(const _config_ptr_t& config, _pool_core_ptr_t pool_core) :
+    ConnectionBase{std::make_unique<_handle_t>(config)},
     _pool_core{pool_core}
   {
   }
 
-  template<typename ConnBase>
-  void conn_pooled<ConnBase>::conn_release()
+  template<typename ConnectionBase>
+  void connection_pooled<ConnectionBase>::conn_release()
   {
     if (_pool_core) {
-      _pool_core->put(ConnBase::_handle);
+      _pool_core->put(ConnectionBase::_handle);
       _pool_core = nullptr;
     }
   }

--- a/include/sqlpp11/connection.h
+++ b/include/sqlpp11/connection.h
@@ -39,22 +39,22 @@ namespace sqlpp
 
   // Normal (non-pooled) connection
   template<typename ConnectionBase>
-  class connection_normal : public ConnectionBase
+  class normal_connection : public ConnectionBase
   {
   public:
     using _config_t = typename ConnectionBase::_config_t;
     using _config_ptr_t = typename ConnectionBase::_config_ptr_t;
 
     // Constructors
-    connection_normal() = default;
-    connection_normal(const _config_t& config);
-    connection_normal(const _config_ptr_t& config);
-    connection_normal(const connection_normal&) = delete;
-    connection_normal(connection_normal&&) = default;
+    normal_connection() = default;
+    normal_connection(const _config_t& config);
+    normal_connection(const _config_ptr_t& config);
+    normal_connection(const normal_connection&) = delete;
+    normal_connection(normal_connection&&) = default;
 
     // Assigment operators
-    connection_normal& operator=(const connection_normal&) = delete;
-    connection_normal& operator=(connection_normal&&) = default;
+    normal_connection& operator=(const normal_connection&) = delete;
+    normal_connection& operator=(normal_connection&&) = default;
 
     // creates a connection handle and connects to database
     void connectUsing(const _config_ptr_t& config) noexcept(false);
@@ -64,19 +64,19 @@ namespace sqlpp
   };
 
   template<typename ConnectionBase>
-  connection_normal<ConnectionBase>::connection_normal(const _config_t& config) :
-    connection_normal{std::make_shared<_config_t>(config)}
+  normal_connection<ConnectionBase>::normal_connection(const _config_t& config) :
+    normal_connection{std::make_shared<_config_t>(config)}
   {
   }
 
   template<typename ConnectionBase>
-  connection_normal<ConnectionBase>::connection_normal(const _config_ptr_t& config) :
+  normal_connection<ConnectionBase>::normal_connection(const _config_ptr_t& config) :
     ConnectionBase{std::make_unique<_handle_t>(config)}
   {
   }
 
   template<typename ConnectionBase>
-  void connection_normal<ConnectionBase>::connectUsing(const _config_ptr_t& config) noexcept(false)
+  void normal_connection<ConnectionBase>::connectUsing(const _config_ptr_t& config) noexcept(false)
   {
     ConnectionBase::_handle = std::make_unique<_handle_t>(config);
   }
@@ -87,7 +87,7 @@ namespace sqlpp
 
   // Pooled connection
   template<typename ConnectionBase>
-  class connection_pooled : public ConnectionBase
+  class pooled_connection : public ConnectionBase
   {
     friend class connection_pool<ConnectionBase>::pool_core;
 
@@ -98,32 +98,32 @@ namespace sqlpp
     using _pool_core_ptr_t = std::shared_ptr<typename connection_pool<ConnectionBase>::pool_core>;
 
     // Copy/Move constructors
-    connection_pooled(const connection_pooled&) = delete;
-    connection_pooled(connection_pooled&& other) = default;
-    ~connection_pooled();
+    pooled_connection(const pooled_connection&) = delete;
+    pooled_connection(pooled_connection&& other) = default;
+    ~pooled_connection();
 
     // Assigment operators
-    connection_pooled& operator=(const connection_pooled&) = delete;
-    connection_pooled& operator=(connection_pooled&& other);
+    pooled_connection& operator=(const pooled_connection&) = delete;
+    pooled_connection& operator=(pooled_connection&& other);
 
   private:
     _pool_core_ptr_t _pool_core;
 
     // Constructors used by the connection pool
-    connection_pooled(_handle_ptr_t&& handle, _pool_core_ptr_t pool_core);
-    connection_pooled(const _config_ptr_t& config, _pool_core_ptr_t pool_core);
+    pooled_connection(_handle_ptr_t&& handle, _pool_core_ptr_t pool_core);
+    pooled_connection(const _config_ptr_t& config, _pool_core_ptr_t pool_core);
 
     void conn_release();
   };
 
   template<typename ConnectionBase>
-  connection_pooled<ConnectionBase>::~connection_pooled()
+  pooled_connection<ConnectionBase>::~pooled_connection()
   {
     conn_release();
   }
 
   template<typename ConnectionBase>
-  connection_pooled<ConnectionBase>& connection_pooled<ConnectionBase>::operator=(connection_pooled&& other)
+  pooled_connection<ConnectionBase>& pooled_connection<ConnectionBase>::operator=(pooled_connection&& other)
   {
     if (this != &other) {
       conn_release();
@@ -134,21 +134,21 @@ namespace sqlpp
   }
 
   template<typename ConnectionBase>
-  connection_pooled<ConnectionBase>::connection_pooled(_handle_ptr_t&& handle, _pool_core_ptr_t pool_core) :
+  pooled_connection<ConnectionBase>::pooled_connection(_handle_ptr_t&& handle, _pool_core_ptr_t pool_core) :
     ConnectionBase{std::move(handle)},
     _pool_core{pool_core}
   {
   }
 
   template<typename ConnectionBase>
-  connection_pooled<ConnectionBase>::connection_pooled(const _config_ptr_t& config, _pool_core_ptr_t pool_core) :
+  pooled_connection<ConnectionBase>::pooled_connection(const _config_ptr_t& config, _pool_core_ptr_t pool_core) :
     ConnectionBase{std::make_unique<_handle_t>(config)},
     _pool_core{pool_core}
   {
   }
 
   template<typename ConnectionBase>
-  void connection_pooled<ConnectionBase>::conn_release()
+  void pooled_connection<ConnectionBase>::conn_release()
   {
     if (_pool_core) {
       _pool_core->put(ConnectionBase::_handle);

--- a/include/sqlpp11/connection.h
+++ b/include/sqlpp11/connection.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013-2015, Roland Bock
+ * Copyright (c) 2023, Vesselin Atanasov
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -27,11 +28,133 @@
 #ifndef SQLPP11_CONNECTION_H
 #define SQLPP11_CONNECTION_H
 
+#include <functional>
+#include <memory>
+
 namespace sqlpp
 {
   struct connection
   {
   };
+
+  // Normal (non-pooled) connection
+  template<typename ConnBase>
+  class conn_normal : public ConnBase
+  {
+  public:
+    using _config_t = typename ConnBase::_config_t;
+    using _config_ptr_t = typename ConnBase::_config_ptr_t;
+
+    // Constructors
+    conn_normal() = default;
+    conn_normal(const _config_t& config);
+    conn_normal(const _config_ptr_t& config);
+    conn_normal(const conn_normal&) = delete;
+    conn_normal(conn_normal&&) = default;
+
+    // Assigment operators
+    conn_normal& operator=(const conn_normal&) = delete;
+    conn_normal& operator=(conn_normal&&) = default;
+
+    // creates a connection handle and connects to database
+    void connectUsing(const _config_ptr_t& config) noexcept(false);
+
+  private:
+    using _handle_t = typename ConnBase::_handle_t;
+  };
+
+  template<typename ConnBase>
+  conn_normal<ConnBase>::conn_normal(const _config_t& config) :
+    conn_normal{std::make_shared<_config_t>(config)}
+  {
+  }
+
+  template<typename ConnBase>
+  conn_normal<ConnBase>::conn_normal(const _config_ptr_t& config) :
+    ConnBase{std::make_unique<_handle_t>(config)}
+  {
+  }
+
+  template<typename ConnBase>
+  void conn_normal<ConnBase>::connectUsing(const _config_ptr_t& config) noexcept(false)
+  {
+    ConnBase::_handle = std::make_unique<_handle_t>(config);
+  }
+
+  // Forward declaration
+  template<typename ConnBase>
+  class connection_pool;
+
+  // Pooled connection
+  template<typename ConnBase>
+  class conn_pooled : public ConnBase
+  {
+    friend class connection_pool<ConnBase>::pool_core;
+
+  public:
+    using _config_ptr_t = typename ConnBase::_config_ptr_t;
+    using _handle_t = typename ConnBase::_handle_t;
+    using _handle_ptr_t = typename ConnBase::_handle_ptr_t;
+    using _pool_core_ptr_t = std::shared_ptr<typename connection_pool<ConnBase>::pool_core>;
+
+    // Copy/Move constructors
+    conn_pooled(const conn_pooled&) = delete;
+    conn_pooled(conn_pooled&& other) = default;
+    ~conn_pooled();
+
+    // Assigment operators
+    conn_pooled& operator=(const conn_pooled&) = delete;
+    conn_pooled& operator=(conn_pooled&& other);
+
+  private:
+    _pool_core_ptr_t _pool_core;
+
+    // Constructors used by the connection pool
+    conn_pooled(_handle_ptr_t&& handle, _pool_core_ptr_t pool_core);
+    conn_pooled(const _config_ptr_t& config, _pool_core_ptr_t pool_core);
+
+    void conn_release();
+  };
+
+  template<typename ConnBase>
+  conn_pooled<ConnBase>::~conn_pooled()
+  {
+    conn_release();
+  }
+
+  template<typename ConnBase>
+  conn_pooled<ConnBase>& conn_pooled<ConnBase>::operator=(conn_pooled&& other)
+  {
+    if (this != &other) {
+      conn_release();
+      static_cast<ConnBase&>(*this) = std::move(static_cast<ConnBase&>(other));
+      _pool_core = std::move(other._pool_core);
+    }
+    return *this;
+  }
+
+  template<typename ConnBase>
+  conn_pooled<ConnBase>::conn_pooled(_handle_ptr_t&& handle, _pool_core_ptr_t pool_core) :
+    ConnBase{std::move(handle)},
+    _pool_core{pool_core}
+  {
+  }
+
+  template<typename ConnBase>
+  conn_pooled<ConnBase>::conn_pooled(const _config_ptr_t& config, _pool_core_ptr_t pool_core) :
+    ConnBase{std::make_unique<_handle_t>(config)},
+    _pool_core{pool_core}
+  {
+  }
+
+  template<typename ConnBase>
+  void conn_pooled<ConnBase>::conn_release()
+  {
+    if (_pool_core) {
+      _pool_core->put(ConnBase::_handle);
+      _pool_core = nullptr;
+    }
+  }
 }  // namespace sqlpp
 
 #endif

--- a/include/sqlpp11/connection_pool.h
+++ b/include/sqlpp11/connection_pool.h
@@ -1,0 +1,151 @@
+#pragma once
+
+/*
+Copyright (c) 2017 - 2018, Roland Bock
+Copyright (c) 2023, Vesselin Atanasov
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this
+   list of conditions and the following disclaimer in the documentation and/or
+   other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <mutex>
+
+#include <sqlpp11/detail/circular_buffer.h>
+
+namespace sqlpp
+{
+  template<typename ConnBase>
+  class connection_pool
+  {
+  public:
+    using _config_ptr_t = typename ConnBase::_config_ptr_t;
+    using _handle_ptr_t = typename ConnBase::_handle_ptr_t;
+    using _conn_pooled_t = sqlpp::conn_pooled<ConnBase>;
+
+    class pool_core : public std::enable_shared_from_this<pool_core>
+    {
+    public:
+      pool_core(const _config_ptr_t& connection_config, std::size_t capacity);
+      pool_core() = delete;
+      pool_core(const pool_core &) = delete;
+      pool_core(pool_core &&) = delete;
+
+      pool_core& operator=(const pool_core&) = delete;
+      pool_core& operator=(pool_core&&) = delete;
+
+      _conn_pooled_t get();
+      void put(_handle_ptr_t& handle);
+      // Returns number of connections available in the pool. Only used in tests.
+      std::size_t available();
+
+    private:
+      _config_ptr_t _connection_config;
+      sqlpp::detail::circular_buffer<_handle_ptr_t> _handles;
+      std::mutex _mutex;
+    };
+
+    connection_pool() = default;
+    connection_pool(const _config_ptr_t& connection_config, std::size_t capacity);
+    connection_pool(const connection_pool&) = delete;
+    connection_pool(connection_pool&&) = default;
+
+    connection_pool& operator=(const connection_pool&) = delete;
+    connection_pool& operator=(connection_pool&&) = default;
+
+    void initialize(const _config_ptr_t& connection_config, std::size_t capacity);
+    _conn_pooled_t get();
+    // Returns number of connections available in the pool. Only used in tests.
+    std::size_t available();
+
+  private:
+    std::shared_ptr<pool_core> _core;
+  };
+
+  template<typename ConnBase>
+  connection_pool<ConnBase>::pool_core::pool_core(const _config_ptr_t& connection_config, std::size_t capacity) :
+    _connection_config{connection_config},
+    _handles{capacity}
+  {
+  }
+
+  template<typename ConnBase>
+  typename connection_pool<ConnBase>::_conn_pooled_t connection_pool<ConnBase>::pool_core::get()
+  {
+    std::unique_lock lock{_mutex};
+    if (_handles.empty()) {
+      lock.unlock();
+      return _conn_pooled_t{_connection_config, this->shared_from_this()};
+    }
+    auto handle = std::move(_handles.front());
+    _handles.pop_front();
+    lock.unlock();
+    // If the fetched connection is dead, drop it and create a new one on the fly
+    return
+      handle->check_connection() ?
+      _conn_pooled_t{std::move(handle), this->shared_from_this()} :
+      _conn_pooled_t{_connection_config, this->shared_from_this()};
+  }
+
+  template<typename ConnBase>
+  void connection_pool<ConnBase>::pool_core::put(_handle_ptr_t& handle)
+  {
+    std::unique_lock lock{_mutex};
+    if (_handles.full ()) {
+            _handles.set_capacity (_handles.capacity () + 5);
+    }
+    _handles.push_back(std::move(handle));
+  }
+
+  template<typename ConnBase>
+  std::size_t connection_pool<ConnBase>::pool_core::available()
+  {
+    std::unique_lock lock{_mutex};
+    return _handles.size();
+  }
+
+  template<typename ConnBase>
+  connection_pool<ConnBase>::connection_pool(const _config_ptr_t& connection_config, std::size_t capacity) :
+    _core{std::make_shared<pool_core>(connection_config, capacity)}
+  {
+  }
+
+  template<typename ConnBase>
+  void connection_pool<ConnBase>::initialize(const _config_ptr_t& connection_config, std::size_t capacity)
+  {
+    if (_core) {
+      throw std::runtime_error{"Connection pool already initialized"};
+    }
+    _core = std::make_shared<pool_core>(connection_config, capacity);
+  }
+
+  template<typename ConnBase>
+  typename connection_pool<ConnBase>::_conn_pooled_t connection_pool<ConnBase>::get()
+  {
+    return _core->get();
+  }
+
+  template<typename ConnBase>
+  std::size_t connection_pool<ConnBase>::available()
+  {
+    return _core->available();
+  }
+} // namespace sqlpp

--- a/include/sqlpp11/detail/circular_buffer.h
+++ b/include/sqlpp11/detail/circular_buffer.h
@@ -1,0 +1,162 @@
+#pragma once
+
+/*
+Copyright (c) 2017 - 2018, Roland Bock
+Copyright (c) 2023, Vesselin Atanasov
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this
+   list of conditions and the following disclaimer in the documentation and/or
+   other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <algorithm>
+#include <stdexcept>
+#include <vector>
+
+namespace sqlpp
+{
+  namespace detail
+  {
+    // This class is modelled after boost::circular_buffer
+    template <typename T>
+    class circular_buffer
+    {
+    public:
+      circular_buffer(std::size_t capacity);
+      std::size_t capacity() const;
+      void set_capacity(std::size_t capacity);
+      std::size_t size() const;
+      bool empty() const;
+      bool full() const;
+      T& front();
+      void pop_front();
+      void push_back(T&& t);
+
+    private:
+      std::vector<T> _data;
+      std::size_t _capacity;
+      std::size_t _size;
+      std::size_t _head;
+      std::size_t _tail;
+
+      void increment(std::size_t& pos);
+    };
+
+    template <typename T>
+    circular_buffer<T>::circular_buffer(std::size_t capacity) :
+      _data(capacity),
+      _capacity{capacity},
+      _size{0},
+      _head{0},
+      _tail{0}
+    {
+    }
+
+    template <typename T>
+    std::size_t circular_buffer<T>::capacity() const
+    {
+      return _capacity;
+    }
+
+    template <typename T>
+    void circular_buffer<T>::set_capacity(std::size_t capacity)
+    {
+      if (capacity == _capacity) {
+        return;
+      }
+      if (_tail >= _head) {
+        if (empty () == false) {
+          std::rotate(_data.begin(), _data.begin()+_tail, _data.end());
+        }
+        _head = (capacity > _size) ? _size : 0;
+        _tail = 0;
+      } else {
+        if (capacity < _head) {
+          std::rotate(_data.begin(), _data.begin()+_tail, _data.begin()+_head);
+          _head = (capacity > _size) ? _size : 0;
+          _tail = 0;
+        } else if (capacity == _head) {
+          _head = 0;
+        }
+      }
+      _data.resize(capacity);
+      _capacity = capacity;
+      if (_size > capacity) {
+        _size = capacity;
+      }
+    }
+
+    template <typename T>
+    std::size_t circular_buffer<T>::size() const
+    {
+      return _size;
+    }
+
+    template <typename T>
+    bool circular_buffer<T>::empty() const
+    {
+      return _size == 0;
+    }
+
+    template <typename T>
+    bool circular_buffer<T>::full() const
+    {
+      return _size == _capacity;
+    }
+
+    template <typename T>
+    T& circular_buffer<T>::front()
+    {
+      if (empty()) {
+        throw std::runtime_error{"circular_buffer::front() called on empty buffer"};
+      }
+      return _data[_tail];
+    }
+
+    template <typename T>
+    void circular_buffer<T>::pop_front()
+    {
+      if (empty()) {
+        throw std::runtime_error{"circular_buffer::pop_front() called on empty buffer"};
+      }
+      _data[_tail] = {};
+      increment(_tail);
+      --_size;
+    }
+
+    template <typename T>
+    void circular_buffer<T>::push_back(T&& t)
+    {
+      if (full()) {
+        throw std::runtime_error{"circular_buffer::push_back() called on full buffer"};
+      }
+      _data[_head] = std::move(t);
+      increment(_head);
+      ++_size;
+    }
+
+    template <typename T>
+    void circular_buffer<T>::increment(std::size_t& pos)
+    {
+      pos = (pos + 1) % _capacity;
+    }
+  }  // namespace detail
+}  // namespace sqlpp

--- a/include/sqlpp11/eval.h
+++ b/include/sqlpp11/eval.h
@@ -51,7 +51,7 @@ namespace sqlpp
   template <typename Db,
             typename Expr,
             typename std::enable_if<not std::is_convertible<Expr, std::string>::value, int>::type = 0>
-  auto eval(Db& db, Expr expr) -> typename eval_t<Db, Expr>::type
+  auto eval(Db& db, Expr expr) -> typename eval_t<typename Db::_conn_base_t, Expr>::type
   {
     return db(select(expr.as(alias::a))).front().a;
   }

--- a/include/sqlpp11/eval.h
+++ b/include/sqlpp11/eval.h
@@ -51,7 +51,7 @@ namespace sqlpp
   template <typename Db,
             typename Expr,
             typename std::enable_if<not std::is_convertible<Expr, std::string>::value, int>::type = 0>
-  auto eval(Db& db, Expr expr) -> typename eval_t<typename Db::_conn_base_t, Expr>::type
+  auto eval(Db& db, Expr expr) -> typename eval_t<typename Db::_connection_base_t, Expr>::type
   {
     return db(select(expr.as(alias::a))).front().a;
   }

--- a/include/sqlpp11/mysql/connection.h
+++ b/include/sqlpp11/mysql/connection.h
@@ -600,8 +600,8 @@ namespace sqlpp
       return _db.escape(arg);
     }
 
-    using connection = sqlpp::connection_normal<connection_base>;
-    using connection_pooled = sqlpp::connection_pooled<connection_base>;
+    using connection = sqlpp::normal_connection<connection_base>;
+    using pooled_connection = sqlpp::pooled_connection<connection_base>;
   }  // namespace mysql
 }  // namespace sqlpp
 

--- a/include/sqlpp11/mysql/connection.h
+++ b/include/sqlpp11/mysql/connection.h
@@ -234,14 +234,14 @@ namespace sqlpp
     }
 
     // Forward declaration
-    class conn_base;
+    class connection_base;
 
     struct serializer_t
     {
-      serializer_t(const conn_base& db) : _db(db)
+      serializer_t(const connection_base& db) : _db(db)
       {
       }
-      serializer_t(const conn_base&&) = delete;
+      serializer_t(const connection_base&&) = delete;
 
       template <typename T>
       std::ostream& operator<<(T t)
@@ -256,7 +256,7 @@ namespace sqlpp
         return _os.str();
       }
 
-      const conn_base& _db;
+      const connection_base& _db;
       sqlpp::detail::float_safe_ostringstream _os;
     };
 
@@ -264,10 +264,10 @@ namespace sqlpp
 
     std::integral_constant<char, '`'> get_quote_right(const serializer_t&);
 
-    class conn_base : public sqlpp::connection
+    class connection_base : public sqlpp::connection
     {
     public:
-      using _conn_base_t = conn_base;
+      using _connection_base_t = connection_base;
       using _config_t = connection_config;
       using _config_ptr_t = std::shared_ptr<const _config_t>;
       using _handle_t = detail::connection_handle_t;
@@ -521,8 +521,8 @@ namespace sqlpp
       _handle_ptr_t _handle;
 
       // Constructors
-      conn_base() = default;
-      conn_base(_handle_ptr_t&& handle) : _handle{std::move(handle)}
+      connection_base() = default;
+      connection_base(_handle_ptr_t&& handle) : _handle{std::move(handle)}
       {
       }
 
@@ -594,14 +594,14 @@ namespace sqlpp
       }
     };
 
-    // Method definition moved outside of class because it needs conn_base
+    // Method definition moved outside of class because it needs connection_base
     inline std::string serializer_t::escape(std::string arg)
     {
       return _db.escape(arg);
     }
 
-    using connection = sqlpp::conn_normal<conn_base>;
-    using conn_pooled = sqlpp::conn_pooled<conn_base>;
+    using connection = sqlpp::connection_normal<connection_base>;
+    using connection_pooled = sqlpp::connection_pooled<connection_base>;
   }  // namespace mysql
 }  // namespace sqlpp
 

--- a/include/sqlpp11/mysql/connection_config.h
+++ b/include/sqlpp11/mysql/connection_config.h
@@ -33,10 +33,8 @@ namespace sqlpp
 {
   namespace mysql
   {
-    class connection;
     struct connection_config
     {
-      typedef ::sqlpp::mysql::connection connection;
       std::string host = "localhost";
       std::string user;
       std::string password;

--- a/include/sqlpp11/mysql/connection_pool.h
+++ b/include/sqlpp11/mysql/connection_pool.h
@@ -1,0 +1,39 @@
+#pragma once
+
+/*
+Copyright (c) 2017 - 2018, Roland Bock
+Copyright (c) 2023, Vesselin Atanasov
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this
+   list of conditions and the following disclaimer in the documentation and/or
+   other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <sqlpp11/connection_pool.h>
+#include <sqlpp11/mysql/connection.h>
+
+namespace sqlpp
+{
+  namespace mysql
+  {
+    using connection_pool = sqlpp::connection_pool<conn_base>;
+  }  // namespace mysql
+} // namespace sqlpp

--- a/include/sqlpp11/mysql/connection_pool.h
+++ b/include/sqlpp11/mysql/connection_pool.h
@@ -34,6 +34,6 @@ namespace sqlpp
 {
   namespace mysql
   {
-    using connection_pool = sqlpp::connection_pool<conn_base>;
+    using connection_pool = sqlpp::connection_pool<connection_base>;
   }  // namespace mysql
 } // namespace sqlpp

--- a/include/sqlpp11/mysql/mysql.h
+++ b/include/sqlpp11/mysql/mysql.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013 - 2015, Roland Bock
+ * Copyright (c) 2023, Vesselin Atanasov
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -28,6 +29,7 @@
 #define SQLPP_MYSQL_H
 
 #include <sqlpp11/mysql/connection.h>
+#include <sqlpp11/mysql/connection_pool.h>
 #include <sqlpp11/mysql/char_result.h>
 
 #endif

--- a/include/sqlpp11/mysql/prepared_statement.h
+++ b/include/sqlpp11/mysql/prepared_statement.h
@@ -41,11 +41,11 @@ namespace sqlpp
 {
   namespace mysql
   {
-    class conn_base;
+    class connection_base;
 
     class prepared_statement_t
     {
-      friend ::sqlpp::mysql::conn_base;
+      friend ::sqlpp::mysql::connection_base;
       std::shared_ptr<detail::prepared_statement_handle_t> _handle;
 
     public:

--- a/include/sqlpp11/mysql/prepared_statement.h
+++ b/include/sqlpp11/mysql/prepared_statement.h
@@ -41,11 +41,11 @@ namespace sqlpp
 {
   namespace mysql
   {
-    class connection;
+    class conn_base;
 
     class prepared_statement_t
     {
-      friend ::sqlpp::mysql::connection;
+      friend ::sqlpp::mysql::conn_base;
       std::shared_ptr<detail::prepared_statement_handle_t> _handle;
 
     public:

--- a/include/sqlpp11/postgresql/connection.h
+++ b/include/sqlpp11/postgresql/connection.h
@@ -88,15 +88,15 @@ namespace sqlpp
     }
 
     // Forward declaration
-    class conn_base;
+    class connection_base;
 
     // Context
     struct context_t
     {
-      context_t(const conn_base& db) : _db(db)
+      context_t(const connection_base& db) : _db(db)
       {
       }
-      context_t(const conn_base&&) = delete;
+      context_t(const connection_base&&) = delete;
 
       template <typename T>
       std::ostream& operator<<(T t)
@@ -126,16 +126,16 @@ namespace sqlpp
         ++_count;
       }
 
-      const conn_base& _db;
+      const connection_base& _db;
       sqlpp::detail::float_safe_ostringstream _os;
       size_t _count{1};
     };
 
     // Base connection class
-    class conn_base : public sqlpp::connection
+    class connection_base : public sqlpp::connection
     {
     public:
-      using _conn_base_t = conn_base;
+      using _connection_base_t = connection_base;
       using _config_t = connection_config;
       using _config_ptr_t = std::shared_ptr<const _config_t>;
       using _handle_t = detail::connection_handle;
@@ -525,8 +525,8 @@ namespace sqlpp
       _handle_ptr_t _handle;
 
       // Constructors
-      conn_base() = default;
-      conn_base(_handle_ptr_t&& handle) : _handle{std::move(handle)}
+      connection_base() = default;
+      connection_base(_handle_ptr_t&& handle) : _handle{std::move(handle)}
       {
       }
 
@@ -604,14 +604,14 @@ namespace sqlpp
       }
     };
 
-    // Method definition moved outside of class because it needs conn_base
+    // Method definition moved outside of class because it needs connection_base
     inline std::string context_t::escape(const std::string& arg) const
     {
       return _db.escape(arg);
     }
 
-    using connection = sqlpp::conn_normal<conn_base>;
-    using conn_pooled = sqlpp::conn_pooled<conn_base>;
+    using connection = sqlpp::connection_normal<connection_base>;
+    using connection_pooled = sqlpp::connection_pooled<connection_base>;
   }  // namespace postgresql
 }  // namespace sqlpp
 

--- a/include/sqlpp11/postgresql/connection.h
+++ b/include/sqlpp11/postgresql/connection.h
@@ -610,8 +610,8 @@ namespace sqlpp
       return _db.escape(arg);
     }
 
-    using connection = sqlpp::connection_normal<connection_base>;
-    using connection_pooled = sqlpp::connection_pooled<connection_base>;
+    using connection = sqlpp::normal_connection<connection_base>;
+    using pooled_connection = sqlpp::pooled_connection<connection_base>;
   }  // namespace postgresql
 }  // namespace sqlpp
 

--- a/include/sqlpp11/postgresql/connection.h
+++ b/include/sqlpp11/postgresql/connection.h
@@ -134,6 +134,79 @@ namespace sqlpp
     // Base connection class
     class connection_base : public sqlpp::connection
     {
+    private:
+      bool _transaction_active{false};
+
+      void validate_connection_handle() const
+      {
+        if (!_handle) {
+          throw std::logic_error("connection handle used, but not initialized");
+        }
+      }
+
+      // direct execution
+      bind_result_t select_impl(const std::string& stmt)
+      {
+        return execute(stmt);
+      }
+
+      size_t insert_impl(const std::string& stmt)
+      {
+        return static_cast<size_t>(execute(stmt)->result.affected_rows());
+      }
+
+      size_t update_impl(const std::string& stmt)
+      {
+        return static_cast<size_t>(execute(stmt)->result.affected_rows());
+      }
+
+      size_t remove_impl(const std::string& stmt)
+      {
+        return static_cast<size_t>(execute(stmt)->result.affected_rows());
+      }
+
+      // prepared execution
+      prepared_statement_t prepare_impl(const std::string& stmt, const size_t& paramCount)
+      {
+        validate_connection_handle();
+        return {prepare_statement(_handle, stmt, paramCount)};
+      }
+
+      bind_result_t run_prepared_select_impl(prepared_statement_t& prep)
+      {
+        validate_connection_handle();
+        execute_prepared_statement(_handle, prep._handle);
+        return {prep._handle};
+      }
+
+      size_t run_prepared_execute_impl(prepared_statement_t& prep)
+      {
+        validate_connection_handle();
+        execute_prepared_statement(_handle, prep._handle);
+        return static_cast<size_t>(prep._handle->result.affected_rows());
+      }
+
+      size_t run_prepared_insert_impl(prepared_statement_t& prep)
+      {
+        validate_connection_handle();
+        execute_prepared_statement(_handle, prep._handle);
+        return static_cast<size_t>(prep._handle->result.affected_rows());
+      }
+
+      size_t run_prepared_update_impl(prepared_statement_t& prep)
+      {
+        validate_connection_handle();
+        execute_prepared_statement(_handle, prep._handle);
+        return static_cast<size_t>(prep._handle->result.affected_rows());
+      }
+
+      size_t run_prepared_remove_impl(prepared_statement_t& prep)
+      {
+        validate_connection_handle();
+        execute_prepared_statement(_handle, prep._handle);
+        return static_cast<size_t>(prep._handle->result.affected_rows());
+      }
+
     public:
       using _connection_base_t = connection_base;
       using _config_t = connection_config;
@@ -528,79 +601,6 @@ namespace sqlpp
       connection_base() = default;
       connection_base(_handle_ptr_t&& handle) : _handle{std::move(handle)}
       {
-      }
-
-    private:
-      bool _transaction_active{false};
-
-      void validate_connection_handle() const
-      {
-        if (!_handle) {
-          throw std::logic_error("connection handle used, but not initialized");
-        }
-      }
-
-      // direct execution
-      bind_result_t select_impl(const std::string& stmt)
-      {
-        return execute(stmt);
-      }
-
-      size_t insert_impl(const std::string& stmt)
-      {
-        return static_cast<size_t>(execute(stmt)->result.affected_rows());
-      }
-
-      size_t update_impl(const std::string& stmt)
-      {
-        return static_cast<size_t>(execute(stmt)->result.affected_rows());
-      }
-
-      size_t remove_impl(const std::string& stmt)
-      {
-        return static_cast<size_t>(execute(stmt)->result.affected_rows());
-      }
-
-      // prepared execution
-      prepared_statement_t prepare_impl(const std::string& stmt, const size_t& paramCount)
-      {
-        validate_connection_handle();
-        return {prepare_statement(_handle, stmt, paramCount)};
-      }
-
-      bind_result_t run_prepared_select_impl(prepared_statement_t& prep)
-      {
-        validate_connection_handle();
-        execute_prepared_statement(_handle, prep._handle);
-        return {prep._handle};
-      }
-
-      size_t run_prepared_execute_impl(prepared_statement_t& prep)
-      {
-        validate_connection_handle();
-        execute_prepared_statement(_handle, prep._handle);
-        return static_cast<size_t>(prep._handle->result.affected_rows());
-      }
-
-      size_t run_prepared_insert_impl(prepared_statement_t& prep)
-      {
-        validate_connection_handle();
-        execute_prepared_statement(_handle, prep._handle);
-        return static_cast<size_t>(prep._handle->result.affected_rows());
-      }
-
-      size_t run_prepared_update_impl(prepared_statement_t& prep)
-      {
-        validate_connection_handle();
-        execute_prepared_statement(_handle, prep._handle);
-        return static_cast<size_t>(prep._handle->result.affected_rows());
-      }
-
-      size_t run_prepared_remove_impl(prepared_statement_t& prep)
-      {
-        validate_connection_handle();
-        execute_prepared_statement(_handle, prep._handle);
-        return static_cast<size_t>(prep._handle->result.affected_rows());
       }
     };
 

--- a/include/sqlpp11/postgresql/connection.h
+++ b/include/sqlpp11/postgresql/connection.h
@@ -191,7 +191,7 @@ namespace sqlpp
       template <typename Select>
       bind_result_t select(const Select& s)
       {
-        _context_t ctx{*this};
+        _context_t ctx(*this);
         serialize(s, ctx);
         return select_impl(ctx.str());
       }
@@ -200,7 +200,7 @@ namespace sqlpp
       template <typename Select>
       _prepared_statement_t prepare_select(Select& s)
       {
-        _context_t ctx{*this};
+        _context_t ctx(*this);
         serialize(s, ctx);
         return prepare_impl(ctx.str(), ctx.count() - 1);
       }
@@ -216,7 +216,7 @@ namespace sqlpp
       template <typename Insert>
       size_t insert(const Insert& i)
       {
-        _context_t ctx{*this};
+        _context_t ctx(*this);
         serialize(i, ctx);
         return insert_impl(ctx.str());
       }
@@ -224,7 +224,7 @@ namespace sqlpp
       template <typename Insert>
       prepared_statement_t prepare_insert(Insert& i)
       {
-        _context_t ctx{*this};
+        _context_t ctx(*this);
         serialize(i, ctx);
         return prepare_impl(ctx.str(), ctx.count() - 1);
       }
@@ -240,7 +240,7 @@ namespace sqlpp
       template <typename Update>
       size_t update(const Update& u)
       {
-        _context_t ctx{*this};
+        _context_t ctx(*this);
         serialize(u, ctx);
         return update_impl(ctx.str());
       }
@@ -248,7 +248,7 @@ namespace sqlpp
       template <typename Update>
       prepared_statement_t prepare_update(Update& u)
       {
-        _context_t ctx{*this};
+        _context_t ctx(*this);
         serialize(u, ctx);
         return prepare_impl(ctx.str(), ctx.count() - 1);
       }
@@ -264,7 +264,7 @@ namespace sqlpp
       template <typename Remove>
       size_t remove(const Remove& r)
       {
-        _context_t ctx{*this};
+        _context_t ctx(*this);
         serialize(r, ctx);
         return remove_impl(ctx.str());
       }
@@ -272,7 +272,7 @@ namespace sqlpp
       template <typename Remove>
       prepared_statement_t prepare_remove(Remove& r)
       {
-        _context_t ctx{*this};
+        _context_t ctx(*this);
         serialize(r, ctx);
         return prepare_impl(ctx.str(), ctx.count() - 1);
       }
@@ -292,7 +292,7 @@ namespace sqlpp
           typename Enable = typename std::enable_if<not std::is_convertible<Execute, std::string>::value, void>::type>
       std::shared_ptr<detail::statement_handle_t> execute(const Execute& x)
       {
-        _context_t ctx{*this};
+        _context_t ctx(*this);
         serialize(x, ctx);
         return execute(ctx.str());
       }
@@ -300,7 +300,7 @@ namespace sqlpp
       template <typename Execute>
       _prepared_statement_t prepare_execute(Execute& x)
       {
-        _context_t ctx{*this};
+        _context_t ctx(*this);
         serialize(x, ctx);
         return prepare_impl(ctx.str(), ctx.count() - 1);
       }

--- a/include/sqlpp11/postgresql/connection_config.h
+++ b/include/sqlpp11/postgresql/connection_config.h
@@ -35,12 +35,8 @@ namespace sqlpp
 {
   namespace postgresql
   {
-    class connection;
     struct DLL_PUBLIC connection_config
     {
-      // Needed for the connection pool
-      typedef ::sqlpp::postgresql::connection connection;
-
       enum class sslmode_t
       {
         disable,

--- a/include/sqlpp11/postgresql/connection_pool.h
+++ b/include/sqlpp11/postgresql/connection_pool.h
@@ -1,0 +1,39 @@
+#pragma once
+
+/*
+Copyright (c) 2017 - 2018, Roland Bock
+Copyright (c) 2023, Vesselin Atanasov
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this
+   list of conditions and the following disclaimer in the documentation and/or
+   other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <sqlpp11/connection_pool.h>
+#include <sqlpp11/postgresql/connection.h>
+
+namespace sqlpp
+{
+  namespace postgresql
+  {
+    using connection_pool = sqlpp::connection_pool<conn_base>;
+  }  // namespace postgresql
+} // namespace sqlpp

--- a/include/sqlpp11/postgresql/connection_pool.h
+++ b/include/sqlpp11/postgresql/connection_pool.h
@@ -34,6 +34,6 @@ namespace sqlpp
 {
   namespace postgresql
   {
-    using connection_pool = sqlpp::connection_pool<conn_base>;
+    using connection_pool = sqlpp::connection_pool<connection_base>;
   }  // namespace postgresql
 } // namespace sqlpp

--- a/include/sqlpp11/postgresql/detail/prepared_statement_handle.h
+++ b/include/sqlpp11/postgresql/detail/prepared_statement_handle.h
@@ -164,7 +164,7 @@ namespace sqlpp
         valid = false;
         count = 0;
         totalCount = 0;
-        result = PQexecPrepared(connection.native(), _name.data(), static_cast<int>(size), values.data(), nullptr, nullptr, 0);
+        result = PQexecPrepared(connection.native_handle(), _name.data(), static_cast<int>(size), values.data(), nullptr, nullptr, 0);
 		/// @todo validate result? is it really valid
         valid = true;
       }
@@ -188,7 +188,7 @@ namespace sqlpp
       inline void prepared_statement_handle_t::prepare(std::string stmt)
       {
         // Create the prepared statement
-        result = PQprepare(connection.native(), _name.c_str(), stmt.c_str(), 0, nullptr);
+        result = PQprepare(connection.native_handle(), _name.c_str(), stmt.c_str(), 0, nullptr);
         valid = true;
       }
     }

--- a/include/sqlpp11/postgresql/postgresql.h
+++ b/include/sqlpp11/postgresql/postgresql.h
@@ -1,5 +1,6 @@
 /**
  * Copyright © 2014-2015, Matthijs Möhlmann
+ * Copyright (c) 2023, Vesselin Atanasov
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,6 +30,7 @@
 #define SQLPP_POSTGRESQL_H
 
 #include <sqlpp11/postgresql/connection.h>
+#include <sqlpp11/postgresql/connection_pool.h>
 #include <sqlpp11/postgresql/exception.h>
 #include <sqlpp11/postgresql/insert.h>
 #include <sqlpp11/postgresql/update.h>

--- a/include/sqlpp11/postgresql/prepared_statement.h
+++ b/include/sqlpp11/postgresql/prepared_statement.h
@@ -44,7 +44,7 @@ namespace sqlpp
 #endif
 
     // Forward declaration
-    class conn_base;
+    class connection_base;
 
     // Detail namespace
     namespace detail
@@ -55,7 +55,7 @@ namespace sqlpp
     class prepared_statement_t
     {
     private:
-      friend class sqlpp::postgresql::conn_base;
+      friend class sqlpp::postgresql::connection_base;
 
       std::shared_ptr<detail::prepared_statement_handle_t> _handle;
 

--- a/include/sqlpp11/postgresql/prepared_statement.h
+++ b/include/sqlpp11/postgresql/prepared_statement.h
@@ -44,7 +44,7 @@ namespace sqlpp
 #endif
 
     // Forward declaration
-    class connection;
+    class conn_base;
 
     // Detail namespace
     namespace detail
@@ -54,9 +54,9 @@ namespace sqlpp
 
     class prepared_statement_t
     {
-      friend sqlpp::postgresql::connection;
-
     private:
+      friend class sqlpp::postgresql::conn_base;
+
       std::shared_ptr<detail::prepared_statement_handle_t> _handle;
 
     public:

--- a/include/sqlpp11/postgresql/result_field.h
+++ b/include/sqlpp11/postgresql/result_field.h
@@ -40,7 +40,8 @@ namespace sqlpp
 {
   namespace postgresql
   {
-    class connection;
+    // Forward declaration
+    class conn_base;
   }
 
   namespace detail
@@ -93,8 +94,8 @@ namespace sqlpp
   }  // namespace detail
 
   template <typename NameType, bool CanBeNull>
-  struct result_field_t<postgresql::connection, field_spec_t<NameType, blob, CanBeNull>>
-      : public result_field_base<postgresql::connection, field_spec_t<NameType, blob, CanBeNull>>
+  struct result_field_t<postgresql::conn_base, field_spec_t<NameType, blob, CanBeNull>>
+      : public result_field_base<postgresql::conn_base, field_spec_t<NameType, blob, CanBeNull>>
   {
   private:
     const uint8_t* _blob{nullptr};  // Non-owning

--- a/include/sqlpp11/postgresql/result_field.h
+++ b/include/sqlpp11/postgresql/result_field.h
@@ -41,7 +41,7 @@ namespace sqlpp
   namespace postgresql
   {
     // Forward declaration
-    class conn_base;
+    class connection_base;
   }
 
   namespace detail
@@ -94,8 +94,8 @@ namespace sqlpp
   }  // namespace detail
 
   template <typename NameType, bool CanBeNull>
-  struct result_field_t<postgresql::conn_base, field_spec_t<NameType, blob, CanBeNull>>
-      : public result_field_base<postgresql::conn_base, field_spec_t<NameType, blob, CanBeNull>>
+  struct result_field_t<postgresql::connection_base, field_spec_t<NameType, blob, CanBeNull>>
+      : public result_field_base<postgresql::connection_base, field_spec_t<NameType, blob, CanBeNull>>
   {
   private:
     const uint8_t* _blob{nullptr};  // Non-owning

--- a/include/sqlpp11/sqlite3/connection.h
+++ b/include/sqlpp11/sqlite3/connection.h
@@ -614,8 +614,8 @@ namespace sqlpp
       return _db.escape(arg);
     }
 
-    using connection = sqlpp::connection_normal<connection_base>;
-    using connection_pooled = sqlpp::connection_pooled<connection_base>;
+    using connection = sqlpp::normal_connection<connection_base>;
+    using pooled_connection = sqlpp::pooled_connection<connection_base>;
   }  // namespace sqlite3
 }  // namespace sqlpp
 

--- a/include/sqlpp11/sqlite3/connection.h
+++ b/include/sqlpp11/sqlite3/connection.h
@@ -166,11 +166,11 @@ namespace sqlpp
     }  // namespace detail
 
     // Forward declaration
-    class conn_base;
+    class connection_base;
 
     struct serializer_t
     {
-      serializer_t(const conn_base& db) : _db(db), _count(1)
+      serializer_t(const connection_base& db) : _db(db), _count(1)
       {
       }
 
@@ -197,16 +197,16 @@ namespace sqlpp
         ++_count;
       }
 
-      const conn_base& _db;
+      const connection_base& _db;
       sqlpp::detail::float_safe_ostringstream _os;
       size_t _count;
     };
 
     // Base connection class
-    class SQLPP11_SQLITE3_EXPORT conn_base : public sqlpp::connection
+    class SQLPP11_SQLITE3_EXPORT connection_base : public sqlpp::connection
     {
     public:
-      using _conn_base_t = conn_base;
+      using _connection_base_t = connection_base;
       using _config_t = connection_config;
       using _config_ptr_t = std::shared_ptr<const connection_config>;
       using _handle_t = detail::connection_handle;
@@ -517,8 +517,8 @@ namespace sqlpp
       _handle_ptr_t _handle;
 
       // Constructors
-      conn_base() = default;
-      conn_base(_handle_ptr_t&& handle) : _handle{std::move(handle)}
+      connection_base() = default;
+      connection_base(_handle_ptr_t&& handle) : _handle{std::move(handle)}
       {
       }
 
@@ -608,14 +608,14 @@ namespace sqlpp
       }
     };
 
-    // Method definition moved outside of class because it needs conn_base
+    // Method definition moved outside of class because it needs connection_base
     inline std::string serializer_t::escape(std::string arg)
     {
       return _db.escape(arg);
     }
 
-    using connection = sqlpp::conn_normal<conn_base>;
-    using conn_pooled = sqlpp::conn_pooled<conn_base>;
+    using connection = sqlpp::connection_normal<connection_base>;
+    using connection_pooled = sqlpp::connection_pooled<connection_base>;
   }  // namespace sqlite3
 }  // namespace sqlpp
 

--- a/include/sqlpp11/sqlite3/connection_pool.h
+++ b/include/sqlpp11/sqlite3/connection_pool.h
@@ -34,6 +34,6 @@ namespace sqlpp
 {
   namespace sqlite3
   {
-    using connection_pool = sqlpp::connection_pool<conn_base>;
+    using connection_pool = sqlpp::connection_pool<connection_base>;
   }  // namespace sqlite3
 } // namespace sqlpp

--- a/include/sqlpp11/sqlite3/connection_pool.h
+++ b/include/sqlpp11/sqlite3/connection_pool.h
@@ -1,0 +1,39 @@
+#pragma once
+
+/*
+Copyright (c) 2017 - 2018, Roland Bock
+Copyright (c) 2023, Vesselin Atanasov
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this
+   list of conditions and the following disclaimer in the documentation and/or
+   other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <sqlpp11/connection_pool.h>
+#include <sqlpp11/sqlite3/connection.h>
+
+namespace sqlpp
+{
+  namespace sqlite3
+  {
+    using connection_pool = sqlpp::connection_pool<conn_base>;
+  }  // namespace sqlite3
+} // namespace sqlpp

--- a/include/sqlpp11/sqlite3/prepared_statement.h
+++ b/include/sqlpp11/sqlite3/prepared_statement.h
@@ -49,6 +49,9 @@ namespace sqlpp
 {
   namespace sqlite3
   {
+    // Forward declaration
+    class conn_base;
+
     namespace detail
     {
       inline void check_bind_result(int result, const char* const type)
@@ -70,11 +73,9 @@ namespace sqlpp
       }
     }  // namespace detail
 
-    class connection;
-
     class SQLPP11_SQLITE3_EXPORT prepared_statement_t
     {
-      friend ::sqlpp::sqlite3::connection;
+      friend class ::sqlpp::sqlite3::conn_base;
       std::shared_ptr<detail::prepared_statement_handle_t> _handle;
 
     public:

--- a/include/sqlpp11/sqlite3/prepared_statement.h
+++ b/include/sqlpp11/sqlite3/prepared_statement.h
@@ -50,7 +50,7 @@ namespace sqlpp
   namespace sqlite3
   {
     // Forward declaration
-    class conn_base;
+    class connection_base;
 
     namespace detail
     {
@@ -75,7 +75,7 @@ namespace sqlpp
 
     class SQLPP11_SQLITE3_EXPORT prepared_statement_t
     {
-      friend class ::sqlpp::sqlite3::conn_base;
+      friend class ::sqlpp::sqlite3::connection_base;
       std::shared_ptr<detail::prepared_statement_handle_t> _handle;
 
     public:

--- a/include/sqlpp11/sqlite3/prepared_statement_handle.h
+++ b/include/sqlpp11/sqlite3/prepared_statement_handle.h
@@ -42,8 +42,6 @@ namespace sqlpp
 {
   namespace sqlite3
   {
-    class connection;
-
     namespace detail
     {
       struct prepared_statement_handle_t

--- a/include/sqlpp11/sqlite3/sqlite3.h
+++ b/include/sqlpp11/sqlite3/sqlite3.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013 - 2015, Roland Bock
+ * Copyright (c) 2023, Vesselin Atanasov
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -28,6 +29,7 @@
 #define SQLPP_SQLITE3_H
 
 #include <sqlpp11/sqlite3/connection.h>
+#include <sqlpp11/sqlite3/connection_pool.h>
 #include <sqlpp11/sqlite3/insert_or.h>
 
 #endif

--- a/tests/include/ConnectionPoolTests.h
+++ b/tests/include/ConnectionPoolTests.h
@@ -1,0 +1,260 @@
+#pragma once
+
+/*
+Copyright (c) 2017 - 2018, Roland Bock
+Copyright (c) 2023, Vesselin Atanasov
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this
+   list of conditions and the following disclaimer in the documentation and/or
+   other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <random>
+#include <set>
+#include <thread>
+#include <unordered_set>
+
+#include "TabDepartment.h"
+
+namespace sqlpp
+{
+  namespace test
+  {
+    namespace
+    {
+      template<typename Pool>
+      using native_type = std::decay_t<decltype(std::declval<Pool>().get().native_handle())>;
+
+      template<typename Pool>
+      using native_set = std::unordered_set<native_type<Pool>>;
+
+      template<typename Pool>
+      using pool_conn_type = std::decay_t<decltype(std::declval<Pool>().get())>;
+
+      template<typename Pool>
+      native_set<Pool> get_native_handles(Pool& pool)
+      {
+        native_set<Pool> ns;
+        if (pool.available() == 0) {
+          return ns;
+        }
+        for (;;) {
+          auto handle = pool.get().native_handle();
+          auto insert_res = ns.insert(handle);
+          if (insert_res.second == false) {
+            return ns;
+          }
+        }
+      }
+
+      template <typename Pool>
+      void test_conn_move(Pool& pool)
+      {
+        auto nh_all = get_native_handles(pool);
+        {
+          // Get one connection from the pool
+          auto conn_1 = pool.get();
+          // If the native handles list was empty before getting a connection, then a new connection
+          // was created, so we need to update the set of all native handles
+          if (nh_all.empty()) {
+            nh_all.insert(conn_1.native_handle());
+          }
+          auto nh_removed = nh_all;
+          if (nh_removed.erase(conn_1.native_handle()) != 1) {
+            throw std::logic_error{"Got an unknown native connection handle"};
+          }
+          if (get_native_handles(pool) != nh_removed) {
+            throw std::logic_error{"Could not get correctly a connection from the pool"};
+          }
+          {
+            // Move the pooled connection once
+            auto conn_2 = std::move(conn_1);
+            if (get_native_handles(pool) != nh_removed) {
+              throw std::logic_error{"Moving a connection changes the pool"};
+            }
+
+            // Move the pooled connection again
+            conn_1 = std::move(conn_2);
+            if (get_native_handles(pool) != nh_removed) {
+              throw std::logic_error{"Moving a connection changes the pool"};
+            }
+
+            // The empty connection conn_2 goes out of scope and gets destroyed
+          }
+
+          // Check if destroying an empty connection changed the pool
+          if (get_native_handles(pool) != nh_removed) {
+            throw std::logic_error{"Destroying an empty connection changes the pool"};
+          }
+
+          // The valid connection conn_1 goes out of scope and gets destroyed
+        }
+
+        // Check if destroying a valid connection from the pool returned the handle to the pool
+        if (get_native_handles(pool) != nh_all) {
+          throw std::logic_error{"Destroying a valid connection does not return its handle to the pool"};
+        }
+      }
+
+      template <typename Pool>
+      void test_basic(Pool& pool, const std::string& create_table)
+      {
+        try
+        {
+          auto db = pool.get();
+          db.execute("DROP TABLE IF EXISTS tab_department");
+          db.execute(create_table);
+          model::TabDepartment tabDept = {};
+          db(insert_into(tabDept).default_values());
+        }
+        catch (const std::exception& e)
+        {
+          std::cerr << "Exception in " << __func__ << "\n";
+          throw;
+        }
+      }
+
+      template <typename Pool>
+      void test_single_connection(Pool& pool)
+      {
+        try
+        {
+          auto* handle = [&pool]() {
+            auto db = pool.get();
+            return db.native_handle();
+          }();
+
+          for (auto i = 0; i < 100; ++i)
+          {
+            auto db = pool.get();
+            if (handle != db.native_handle())
+            {
+              std::cerr << "original connection: " << handle << std::endl;
+              std::cerr << "received connection: " << db.native_handle() << std::endl;
+              throw std::logic_error{"Pool acquired more than one connection"};
+            }
+          }
+        }
+        catch (const std::exception& e)
+        {
+          std::cerr << "Exception in " << __func__ << "\n";
+          throw;
+        }
+      }
+
+      template <typename Pool>
+      void test_multiple_connections(Pool& pool)
+      {
+        try
+        {
+          model::TabDepartment tabDept = {};
+          auto connections = std::vector<std::decay_t<decltype(pool.get())>>{};
+          auto pointers = std::set<void*>{};
+          for (auto i = 0; i < 50; ++i)
+          {
+            connections.push_back(pool.get());
+            if (pointers.count(connections.back().native_handle()))
+            {
+              throw std::logic_error{"Pool yielded connection twice (without getting it back in between)"};
+            }
+            pointers.insert(connections.back().native_handle());
+            connections.back()(insert_into(tabDept).default_values());
+          }
+        }
+        catch (const std::exception& e)
+        {
+          std::cerr << "Exception in " << __func__ << "\n";
+          throw;
+        }
+      }
+
+      template <typename Pool>
+      void test_multithreaded(Pool& pool)
+      {
+        std::random_device r;
+        std::default_random_engine random_engine(r());
+        std::uniform_int_distribution<int> uniform_dist(1, 20);
+
+        std::clog << "Run a random number [1,20] of threads\n";
+        std::clog << "Each with a random number [1,20] of {pool.get() & insert}\n";
+
+        try
+        {
+          model::TabDepartment tabDept = {};
+          auto threads = std::vector<std::thread>{};
+          const auto thread_count = uniform_dist(random_engine);
+
+          for (auto i = 0; i < thread_count; ++i)
+          {
+            threads.push_back(std::thread([func = __func__, call_count = uniform_dist(random_engine), &pool, &tabDept]() {
+              try
+              {
+                for (auto k = 0; k < call_count; ++k)
+                {
+                  auto connection = pool.get();
+                  connection(insert_into(tabDept).default_values());
+                }
+              }
+              catch (const std::exception& e)
+              {
+                std::cerr << std::string(func) + ": In-thread exception: " + e.what() + "\n";
+                std::abort();
+              }
+            }));
+          }
+          for (auto&& t : threads)
+          {
+            t.join();
+          }
+        }
+        catch (const std::exception& e)
+        {
+          std::cerr << "Exception in " << __func__ << "\n";
+          throw;
+        }
+      }
+
+      template <typename Pool>
+      void test_destruction_order(typename Pool::_config_ptr_t config)
+      {
+        // Create a pool, get a connection from it and then destroy the pool before the connection
+        auto pool = std::make_unique<Pool>(config, 5);
+        auto conn = pool->get();
+        pool = nullptr;
+      }
+    }
+
+    template <typename Pool>
+    void test_connection_pool (typename Pool::_config_ptr_t config, const std::string& create_table, bool test_mt)
+    {
+      auto pool = Pool {config, 5};
+      sqlpp::test::test_conn_move(pool);
+      sqlpp::test::test_basic(pool, create_table);
+      sqlpp::test::test_single_connection(pool);
+      sqlpp::test::test_multiple_connections(pool);
+      if (test_mt)
+      {
+        sqlpp::test::test_multithreaded(pool);
+      }
+      sqlpp::test::test_destruction_order<Pool>(config);
+    }
+  }  // namespace test
+}  // namespace sqlpp

--- a/tests/include/TabDepartment.h
+++ b/tests/include/TabDepartment.h
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <sqlpp11/table.h>
+#include <sqlpp11/data_types.h>
+#include <sqlpp11/char_sequence.h>
+
+namespace model
+{
+  namespace TabDepartment_
+  {
+    struct Id
+    {
+      struct _alias_t
+      {
+        static constexpr const char _literal[] =  "id";
+        using _name_t = sqlpp::make_char_sequence<sizeof(_literal), _literal>;
+        template<typename T>
+        struct _member_t
+          {
+            T id;
+            T& operator()() { return id; }
+            const T& operator()() const { return id; }
+          };
+      };
+      using _traits = sqlpp::make_traits<sqlpp::integer, sqlpp::tag::must_not_insert, sqlpp::tag::must_not_update, sqlpp::tag::can_be_null>;
+    };
+    struct Name
+    {
+      struct _alias_t
+      {
+        static constexpr const char _literal[] =  "name";
+        using _name_t = sqlpp::make_char_sequence<sizeof(_literal), _literal>;
+        template<typename T>
+        struct _member_t
+          {
+            T name;
+            T& operator()() { return name; }
+            const T& operator()() const { return name; }
+          };
+      };
+      using _traits = sqlpp::make_traits<sqlpp::text, sqlpp::tag::can_be_null>;
+    };
+    struct Division
+    {
+      struct _alias_t
+      {
+        static constexpr const char _literal[] =  "division";
+        using _name_t = sqlpp::make_char_sequence<sizeof(_literal), _literal>;
+        template<typename T>
+        struct _member_t
+          {
+            T division;
+            T& operator()() { return division; }
+            const T& operator()() const { return division; }
+          };
+      };
+      using _traits = sqlpp::make_traits<sqlpp::text>;
+    };
+  } // namespace TabDepartment_
+
+  struct TabDepartment: sqlpp::table_t<TabDepartment,
+               TabDepartment_::Id,
+               TabDepartment_::Name,
+               TabDepartment_::Division>
+  {
+    struct _alias_t
+    {
+      static constexpr const char _literal[] =  "tab_department";
+      using _name_t = sqlpp::make_char_sequence<sizeof(_literal), _literal>;
+      template<typename T>
+      struct _member_t
+      {
+        T tabDepartment;
+        T& operator()() { return tabDepartment; }
+        const T& operator()() const { return tabDepartment; }
+      };
+    };
+  };
+} // namespace model

--- a/tests/mysql/usage/CMakeLists.txt
+++ b/tests/mysql/usage/CMakeLists.txt
@@ -40,6 +40,7 @@ set(test_files
     Truncated.cpp
     Update.cpp
     Remove.cpp
+    ConnectionPool.cpp
 )
 
 create_test_sourcelist(test_sources test_main.cpp ${test_files})

--- a/tests/mysql/usage/ConnectionPool.cpp
+++ b/tests/mysql/usage/ConnectionPool.cpp
@@ -1,0 +1,56 @@
+/*
+Copyright (c) 2017 - 2018, Roland Bock
+Copyright (c) 2023, Vesselin Atanasov
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this
+   list of conditions and the following disclaimer in the documentation and/or
+   other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <sqlpp11/mysql/mysql.h>
+#include <sqlpp11/sqlpp11.h>
+
+#include "../../include/ConnectionPoolTests.h"
+#include "make_test_connection.h"
+
+namespace sql = ::sqlpp::mysql;
+
+int ConnectionPool(int, char*[])
+{
+  try
+  {
+    sqlpp::test::test_connection_pool<sql::connection_pool>(
+      sql::make_test_config(),
+      "CREATE TABLE tab_department ("
+        "id INTEGER PRIMARY KEY AUTO_INCREMENT, "
+        "name CHAR(100), "
+        "division VARCHAR(255) NOT NULL DEFAULT 'engineering'"
+      ")",
+      mysql_thread_safe()
+    );
+  }
+  catch (const std::exception& e)
+  {
+    std::cerr << "Exception: " << e.what() << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/tests/mysql/usage/CustomQuery.cpp
+++ b/tests/mysql/usage/CustomQuery.cpp
@@ -24,6 +24,7 @@
  */
 
 #include <iostream>
+#include "make_test_connection.h"
 #include "TabSample.h"
 #include <sqlpp11/sqlpp11.h>
 #include <sqlpp11/custom_query.h>
@@ -59,28 +60,13 @@ namespace
 
 const auto tab = TabSample{};
 
-namespace mysql = sqlpp::mysql;
+namespace sql = sqlpp::mysql;
 int CustomQuery(int, char*[])
 {
-  mysql::global_library_init();
-
-  auto config = std::make_shared<mysql::connection_config>();
-  config->user = "root";
-  config->database = "sqlpp_mysql";
-  config->debug = true;
+  sql::global_library_init();
   try
   {
-    mysql::connection db(config);
-  }
-  catch (const sqlpp::exception& e)
-  {
-    std::cerr << "For testing, you'll need to create a database sqlpp_mysql for user root (no password)" << std::endl;
-    std::cerr << e.what() << std::endl;
-    return 1;
-  }
-  try
-  {
-    mysql::connection db(config);
+    auto db = sql::make_test_connection();
     db.execute(R"(DROP TABLE IF EXISTS tab_sample)");
     db.execute(R"(CREATE TABLE tab_sample (
 			alpha bigint(20) AUTO_INCREMENT,

--- a/tests/mysql/usage/DateTime.cpp
+++ b/tests/mysql/usage/DateTime.cpp
@@ -23,6 +23,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "make_test_connection.h"
 #include "TabSample.h"
 #include <sqlpp11/mysql/mysql.h>
 #include <sqlpp11/sqlpp11.h>
@@ -68,32 +69,13 @@ namespace
   }
 }
 
-namespace mysql = sqlpp::mysql;
+namespace sql = sqlpp::mysql;
 int DateTime(int, char*[])
 {
-  auto config = std::make_shared<mysql::connection_config>();
-  config->user = "root";
-  config->database = "sqlpp_mysql";
-  config->debug = true;
+  sql::global_library_init();
   try
   {
-    mysql::connection db(config);
-  }
-  catch (const std::exception& e)
-  {
-    std::cerr << "For testing, you'll need to create a database sqlpp_mysql for user root (no password)" << std::endl;
-    std::cerr << e.what() << std::endl;
-    return 1;
-  }
-  catch (...)
-  {
-    std::cerr << "Unknown exception during connect" << std::endl;
-    return 1;
-  }
-
-  try
-  {
-    mysql::connection db(config);
+    auto db = sql::make_test_connection();
     db.execute(R"(SET time_zone = '+00:00')"); // To force MySQL's CURRENT_TIMESTAMP into the right timezone
     db.execute(R"(DROP TABLE IF EXISTS tab_date_time)");
     db.execute(R"(CREATE TABLE tab_date_time (

--- a/tests/mysql/usage/DynamicSelect.cpp
+++ b/tests/mysql/usage/DynamicSelect.cpp
@@ -23,6 +23,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "make_test_connection.h"
 #include "TabSample.h"
 #include <sqlpp11/alias_provider.h>
 #include <sqlpp11/functions.h>
@@ -38,27 +39,13 @@
 
 const auto library_raii = sqlpp::mysql::scoped_library_initializer_t{};
 
-namespace mysql = sqlpp::mysql;
+namespace sql = sqlpp::mysql;
 int DynamicSelect(int, char*[])
 {
-  auto config = std::make_shared<mysql::connection_config>();
-  config->user = "root";
-  config->database = "sqlpp_mysql";
-  config->debug = true;
+  sql::global_library_init();
   try
   {
-    mysql::connection db(config);
-  }
-  catch (const sqlpp::exception& e)
-  {
-    std::cerr << "For testing, you'll need to create a database sqlpp_mysql for user root (no password)" << std::endl;
-    std::cerr << e.what() << std::endl;
-    return 1;
-  }
-
-  try
-  {
-    mysql::connection db(config);
+    auto db = sql::make_test_connection();
     db.execute(R"(DROP TABLE IF EXISTS tab_sample)");
     db.execute(R"(CREATE TABLE tab_sample (
 		alpha bigint(20) DEFAULT NULL,

--- a/tests/mysql/usage/Json.cpp
+++ b/tests/mysql/usage/Json.cpp
@@ -23,6 +23,8 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "make_test_connection.h"
+
 #include <mysql.h>
 #include <iostream>
 
@@ -52,28 +54,13 @@ namespace test
   SQLPP_ALIAS_PROVIDER(value)
 }
 
-namespace mysql = sqlpp::mysql;
+namespace sql = sqlpp::mysql;
 int Json(int, char*[])
 {
-  mysql::global_library_init();
-
-  auto config = std::make_shared<mysql::connection_config>();
-  config->user = "root";
-  config->database = "sqlpp_mysql";
-  config->debug = true;
+  sql::global_library_init();
   try
   {
-    mysql::connection db(config);
-  }
-  catch (const sqlpp::exception& e)
-  {
-    std::cerr << "For testing, you'll need to create a database sqlpp_mysql for user root (no password)" << std::endl;
-    std::cerr << e.what() << std::endl;
-    return 1;
-  }
-  try
-  {
-    mysql::connection db(config);
+    auto db = sql::make_test_connection();
     db.execute(R"(DROP TABLE IF EXISTS tab_json)");
     db.execute(R"(CREATE TABLE tab_json (
 			  data JSON NOT NULL

--- a/tests/mysql/usage/MoveConstructor.cpp
+++ b/tests/mysql/usage/MoveConstructor.cpp
@@ -23,6 +23,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "make_test_connection.h"
 #include "TabSample.h"
 #include <sqlpp11/alias_provider.h>
 #include <sqlpp11/functions.h>
@@ -37,29 +38,15 @@
 #include <iostream>
 #include <vector>
 
-namespace mysql = sqlpp::mysql;
+namespace sql = sqlpp::mysql;
 int MoveConstructor(int, char*[])
 {
-  mysql::global_library_init();
-
-  auto config = std::make_shared<mysql::connection_config>();
-  config->user = "root";
-  config->database = "sqlpp_mysql";
-  config->debug = true;
+  sql::global_library_init();
+  auto config = sql::make_test_config();
   try
   {
-    mysql::connection db(config);
-  }
-  catch (const sqlpp::exception& e)
-  {
-    std::cerr << "For testing, you'll need to create a database sqlpp_mysql for user root (no password)" << std::endl;
-    std::cerr << e.what() << std::endl;
-    return 1;
-  }
-  try
-  {
-    std::vector<sqlpp::mysql::connection> connections;
-    connections.emplace_back(sqlpp::mysql::connection(config));
+    std::vector<sql::connection> connections;
+    connections.emplace_back(sql::connection(config));
 
     connections.at(0).execute(R"(DROP TABLE IF EXISTS tab_sample)");
     connections.at(0).execute(R"(CREATE TABLE tab_sample (

--- a/tests/mysql/usage/Prepared.cpp
+++ b/tests/mysql/usage/Prepared.cpp
@@ -23,6 +23,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "make_test_connection.h"
 #include "TabSample.h"
 #include <cassert>
 #include <sqlpp11/alias_provider.h>
@@ -69,23 +70,10 @@ void testPreparedStatementResult(sql::connection& db)
 
 int Prepared(int, char*[])
 {
-  auto config = std::make_shared<sql::connection_config>();
-  config->user = "root";
-  config->database = "sqlpp_mysql";
-  config->debug = true;
+  sql::global_library_init();
   try
   {
-    sql::connection db(config);
-  }
-  catch (const sqlpp::exception& e)
-  {
-    std::cerr << "For testing, you'll need to create a database sqlpp_mysql for user root (no password)" << std::endl;
-    std::cerr << e.what() << std::endl;
-    return 1;
-  }
-  try
-  {
-    sql::connection db(config);
+    auto db = sql::make_test_connection();
     db.execute(R"(DROP TABLE IF EXISTS tab_sample)");
     db.execute(R"(CREATE TABLE tab_sample (
 		alpha bigint(20) AUTO_INCREMENT,

--- a/tests/mysql/usage/Remove.cpp
+++ b/tests/mysql/usage/Remove.cpp
@@ -23,6 +23,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "make_test_connection.h"
 #include "TabSample.h"
 #include <sqlpp11/mysql/mysql.h>
 #include <sqlpp11/sqlpp11.h>
@@ -36,23 +37,10 @@ namespace sql = sqlpp::mysql;
 
 int Remove(int, char*[])
 {
-  auto config = std::make_shared<sql::connection_config>();
-  config->user = "root";
-  config->database = "sqlpp_mysql";
-  config->debug = true;
+  sql::global_library_init();
   try
   {
-    sql::connection db(config);
-  }
-  catch (const sqlpp::exception& e)
-  {
-    std::cerr << "For testing, you'll need to create a database sqlpp_mysql for user root (no password)" << std::endl;
-    std::cerr << e.what() << std::endl;
-    return 1;
-  }
-  try
-  {
-    sql::connection db(config);
+    auto db = sql::make_test_connection();
     db.execute(R"(DROP TABLE IF EXISTS tab_sample)");
     db.execute(R"(CREATE TABLE tab_sample (
 		alpha bigint(20) AUTO_INCREMENT,

--- a/tests/mysql/usage/Sample.cpp
+++ b/tests/mysql/usage/Sample.cpp
@@ -23,6 +23,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "make_test_connection.h"
 #include "TabSample.h"
 #include <sqlpp11/mysql/mysql.h>
 #include <sqlpp11/sqlpp11.h>
@@ -31,29 +32,13 @@
 #include <iostream>
 #include <vector>
 
-namespace mysql = sqlpp::mysql;
+namespace sql = sqlpp::mysql;
 int Sample(int, char*[])
 {
-  sqlpp::mysql::global_library_init();
-
-  auto config = std::make_shared<mysql::connection_config>();
-  config->user = "root";
-  config->database = "sqlpp_mysql";
-  config->debug = true;
-  config->connect_timeout_seconds = 5;
+  sql::global_library_init();
   try
   {
-    mysql::connection db(config);
-  }
-  catch (const sqlpp::exception& e)
-  {
-    std::cerr << "For testing, you'll need to create a database sqlpp_mysql for user root (no password)" << std::endl;
-    std::cerr << e.what() << std::endl;
-    return 1;
-  }
-  try
-  {
-    mysql::connection db(config);
+    auto db = sql::make_test_connection();
     db.execute(R"(DROP TABLE IF EXISTS tab_sample)");
     db.execute(R"(CREATE TABLE tab_sample (
 			alpha bigint(20) AUTO_INCREMENT,

--- a/tests/mysql/usage/Select.cpp
+++ b/tests/mysql/usage/Select.cpp
@@ -23,6 +23,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "make_test_connection.h"
 #include "TabSample.h"
 #include <cassert>
 #include <sqlpp11/alias_provider.h>
@@ -83,23 +84,9 @@ void testSelectAll(sql::connection& db, int expectedRowCount)
 
 int Select(int, char*[])
 {
-  auto config = std::make_shared<sql::connection_config>();
-  config->user = "root";
-  config->database = "sqlpp_mysql";
-  config->debug = true;
   try
   {
-    sql::connection db(config);
-  }
-  catch (const sqlpp::exception& e)
-  {
-    std::cerr << "For testing, you'll need to create a database sqlpp_mysql for user root (no password)" << std::endl;
-    std::cerr << e.what() << std::endl;
-    return 1;
-  }
-  try
-  {
-    sql::connection db(config);
+    auto db = sql::make_test_connection();
     db.execute(R"(DROP TABLE IF EXISTS tab_sample)");
     db.execute(R"(CREATE TABLE tab_sample (
 		alpha bigint(20) AUTO_INCREMENT,

--- a/tests/mysql/usage/Truncated.cpp
+++ b/tests/mysql/usage/Truncated.cpp
@@ -23,6 +23,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "make_test_connection.h"
 #include "TabSample.h"
 #include <cassert>
 #include <sqlpp11/alias_provider.h>
@@ -44,24 +45,10 @@ const auto tab = TabSample{};
 
 int Truncated(int, char*[])
 {
-  auto config = std::make_shared<sql::connection_config>();
-  config->user = "root";
-  config->database = "sqlpp_mysql";
-  config->debug = true;
-  config->charset = "utf8";
+  sql::global_library_init();
   try
   {
-    sql::connection db(config);
-  }
-  catch (const sqlpp::exception& e)
-  {
-    std::cerr << "For testing, you'll need to create a database sqlpp_mysql for user root (no password)" << std::endl;
-    std::cerr << e.what() << std::endl;
-    return 1;
-  }
-  try
-  {
-    sql::connection db(config);
+    auto db = sql::make_test_connection();
     db.execute(R"(DROP TABLE IF EXISTS tab_sample)");
     db.execute(R"(CREATE TABLE tab_sample (
 		alpha bigint(20) AUTO_INCREMENT,

--- a/tests/mysql/usage/Update.cpp
+++ b/tests/mysql/usage/Update.cpp
@@ -23,6 +23,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "make_test_connection.h"
 #include "TabSample.h"
 #include <sqlpp11/mysql/mysql.h>
 #include <sqlpp11/sqlpp11.h>
@@ -36,23 +37,10 @@ namespace sql = sqlpp::mysql;
 
 int Update(int, char*[])
 {
-  auto config = std::make_shared<sql::connection_config>();
-  config->user = "root";
-  config->database = "sqlpp_mysql";
-  config->debug = true;
+  sql::global_library_init();
   try
   {
-    sql::connection db(config);
-  }
-  catch (const sqlpp::exception& e)
-  {
-    std::cerr << "For testing, you'll need to create a database sqlpp_mysql for user root (no password)" << std::endl;
-    std::cerr << e.what() << std::endl;
-    return 1;
-  }
-  try
-  {
-    sql::connection db(config);
+    auto db = sql::make_test_connection();
     db.execute(R"(DROP TABLE IF EXISTS tab_sample)");
     db.execute(R"(CREATE TABLE tab_sample (
 		alpha bigint(20) AUTO_INCREMENT,

--- a/tests/postgresql/usage/CMakeLists.txt
+++ b/tests/postgresql/usage/CMakeLists.txt
@@ -30,6 +30,7 @@ set(test_files
     Basic.cpp
     BasicConstConfig.cpp
     Blob.cpp
+    ConnectionPool.cpp
     Constructor.cpp
     Date.cpp
     DateTime.cpp

--- a/tests/postgresql/usage/ConnectionPool.cpp
+++ b/tests/postgresql/usage/ConnectionPool.cpp
@@ -1,0 +1,56 @@
+/*
+Copyright (c) 2017 - 2018, Roland Bock
+Copyright (c) 2023, Vesselin Atanasov
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this
+   list of conditions and the following disclaimer in the documentation and/or
+   other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <sqlpp11/postgresql/postgresql.h>
+#include <sqlpp11/sqlpp11.h>
+
+#include "../../include/ConnectionPoolTests.h"
+#include "make_test_connection.h"
+
+namespace sql = ::sqlpp::postgresql;
+
+int ConnectionPool(int, char*[])
+{
+  try
+  {
+    sqlpp::test::test_connection_pool<sql::connection_pool>(
+      sql::make_test_config(),
+      "CREATE TABLE tab_department ("
+        "id SERIAL PRIMARY KEY, "
+        "name CHAR(100), "
+        "division VARCHAR(255) NOT NULL DEFAULT 'engineering'"
+      ")",
+      PQisthreadsafe()
+    );
+  }
+  catch (const std::exception& e)
+  {
+    std::cerr << "Exception: " << e.what() << std::endl;
+    return 1;
+  }
+  return 0;
+}

--- a/tests/postgresql/usage/make_test_connection.h
+++ b/tests/postgresql/usage/make_test_connection.h
@@ -33,12 +33,10 @@ namespace sqlpp
 {
   namespace postgresql
   {
-    // Starts a connection and sets the time zone to UTC
-    inline ::sqlpp::postgresql::connection make_test_connection()
+    // Get configuration for test connection
+    inline std::shared_ptr<sqlpp::postgresql::connection_config> make_test_config()
     {
-      namespace sql = sqlpp::postgresql;
-
-      auto config = std::make_shared<sql::connection_config>();
+      auto config = std::make_shared<sqlpp::postgresql::connection_config>();
 
 #ifdef WIN32
       config->dbname = "test";
@@ -49,6 +47,15 @@ namespace sqlpp
       config->dbname = "sqlpp_postgresql";
       config->debug = true;
 #endif
+      return config;
+    }
+
+    // Starts a connection and sets the time zone to UTC
+    inline ::sqlpp::postgresql::connection make_test_connection()
+    {
+      namespace sql = sqlpp::postgresql;
+
+      auto config = make_test_config();
 
       sql::connection db;
       try

--- a/tests/sqlite3/usage/CMakeLists.txt
+++ b/tests/sqlite3/usage/CMakeLists.txt
@@ -38,6 +38,7 @@ set(test_files
     FloatingPoint.cpp
     Integral.cpp
     Blob.cpp
+    ConnectionPool.cpp
 )
 
 create_test_sourcelist(test_sources test_main.cpp ${test_files})

--- a/tests/sqlite3/usage/ConnectionPool.cpp
+++ b/tests/sqlite3/usage/ConnectionPool.cpp
@@ -1,0 +1,59 @@
+/*
+Copyright (c) 2017 - 2018, Roland Bock
+Copyright (c) 2023, Vesselin Atanasov
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this
+   list of conditions and the following disclaimer in the documentation and/or
+   other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <sqlpp11/sqlite3/sqlite3.h>
+#include <sqlpp11/sqlpp11.h>
+
+#include "../../include/ConnectionPoolTests.h"
+
+namespace sql = ::sqlpp::sqlite3;
+
+int ConnectionPool(int, char*[])
+{
+  try
+  {
+    auto config = std::make_shared<sql::connection_config>();
+    config->path_to_database = "file:testpool?mode=memory&cache=shared";
+    config->flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_URI;
+    config->debug = true;
+    sqlpp::test::test_connection_pool<sql::connection_pool>(
+      config,
+      "CREATE TABLE tab_department ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "name CHAR(100), "
+        "division VARCHAR(255) NOT NULL DEFAULT 'engineering'"
+      ")",
+      sqlite3_threadsafe()
+    );
+  }
+  catch (const std::exception& e)
+  {
+    std::cerr << "Exception: " << e.what() << std::endl;
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
This PR adds support for connection pooling to the PostgreSQL, MySQL and SQLite3 connectors. It also adds tests for the new connection pooling code and updates the sample connector API classes to match the new updated structure of the database connectors.

The connection pooling code is based on the code from sqlpp17, but it also has a number of changes that make it different from the sqlpp17 implementation.

Below is a list of the main differences from a user perspective:

- The sqlpp11 connection pools accept a capacity parameter just like the sqlpp17 version, but this capacity can be increased dynamically if the initial capacity turns out to be insufficient. The sqlpp17 version just drops the old connections and replaces them by new ones.

- The sqlpp11 pooled connections can be moved without losing of connection handles or insertion into the pool of invalid (empty) handles.

- Due to the unification of connector implementations all non-pooled connectors now can be created either from "const std::shared_ptr<const connection_config>&" or from "const connection_config&". Pooled connections cannot be created by the user, they are only created by the connection pool. Also all non-pooled connections now support connectUsing() (originally only the PostgreSQL connector had it).

There are also many changes in the internals. Below are the most important ones:

- The sqlpp17 connection pools had separate implementations for the different database engines. The pools in sqlpp11 use a common template class.

- The sqlpp17 connections were templates having the pool class as a parameter. The base connecitons classes in sqlpp11 are not templates. The non-pooled and pooled classes are templates that derive from the base connection classes. This allows to move most of the common code in the conn_normal and conn_pooled templates, which arguably makes the implementation of the connection pooling code simpler.

- The format connection_handle classes has been unified to a certain extent and I tried to document that in the sample connector api class.

- The connection handles that are stored in the base connector classes are always stored as std::unique_ptr<connection_handle>, because these unique_ptr objects are stored by the connection pool and are used to create connections when requested.

- I also tried to cleanup a bit the code of the MySQL tests.

Admittedly it is a big PR with lots of changes, so please let me know what you think about it.