### PR TITLE
Fix serialization of time points for MySQL

### DIFF
--- a/include/sqlpp11/data_types/time_point/operand.h
+++ b/include/sqlpp11/data_types/time_point/operand.h
@@ -67,7 +67,7 @@ namespace sqlpp
     const auto dp = ::sqlpp::chrono::floor<::date::days>(t._t);
     const auto time = ::date::make_time(t._t - dp);
     const auto ymd = ::date::year_month_day{dp};
-    context << "TIMESTAMP WITH TIME ZONE '" << ymd << ' ' << time << "+00'";
+    context << "TIMESTAMP '" << ymd << ' ' << time << "'";
     return context;
   }
 }  // namespace sqlpp

--- a/include/sqlpp11/postgresql/serializer.h
+++ b/include/sqlpp11/postgresql/serializer.h
@@ -28,6 +28,7 @@
 #ifndef SQLPP_POSTGRESQL_SERIALIZER_H
 #define SQLPP_POSTGRESQL_SERIALIZER_H
 
+#include <sqlpp11/chrono.h>
 #include <sqlpp11/parameter.h>
 #include <sqlpp11/wrap_operand.h>
 
@@ -52,6 +53,16 @@ namespace sqlpp
     }
     context << '\'';
 
+    return context;
+  }
+
+  template <typename Period>
+  postgresql::context_t& serialize(const time_point_operand<Period>& t, postgresql::context_t& context)
+  {
+    const auto dp = ::sqlpp::chrono::floor<::date::days>(t._t);
+    const auto time = ::date::make_time(t._t - dp);
+    const auto ymd = ::date::year_month_day{dp};
+    context << "TIMESTAMP WITH TIME ZONE '" << ymd << ' ' << time << "+00'";
     return context;
   }
 }


### PR DESCRIPTION
This PR fixes serialization of time points for MySQL.

My previous PR which fixed PostgreSQL time zones inadvertently broke serialization of time points for MySQL. Basically the problem is that MySQL only supports "TIMESTAMP" and does not support "TIMESTAMP WITH TIME ZONE" and the PostgreSQL fix assumed incorrectly MySQL support for time zones. This regression caused the test `sqlpp11.mysql.usage.DateTime ` to fail when running MySQL tests.

The regression was not caught by me because when I prepared the PostgreSQL fix, I only ran the core and PostgreSQL tests. Additionally the sqlpp11 github repository seems to run only core tests. I guess from now on I will ran all tests (core+postgresql+mysql+sqlite) before submitting a PR even if that PR affects only one of the connectors.

The fix for the regression is simple - I just restored the original common version of the time point serializer and added a PostgreSQL-specific time point serializer, pretty much like the PostgreSQL-specific serizalizers for parameter_t and blob_operand

All tests (core+postgresql+mysql+sqlite) have been run for this PR and all tests pass successfully.