### PR TITLE
Fix serialization of PostgreSQL time data types

### DIFF
--- a/include/sqlpp11/postgresql/prepared_statement.h
+++ b/include/sqlpp11/postgresql/prepared_statement.h
@@ -199,10 +199,9 @@ namespace sqlpp
       {
         const auto time = ::date::make_time(*value) ;
 
-        // Timezone handling - always treat the value as UTC.
-        // It is assumed that the database timezone is set to UTC, too.
+        // Timezone handling - always treat the local value as UTC.
         std::ostringstream os;
-        os << time;
+        os << time << "+00";
         _handle->paramValues[index] = os.str();
         if (_handle->debug())
         {
@@ -225,10 +224,9 @@ namespace sqlpp
         const auto time = ::date::make_time(::sqlpp::chrono::floor<::std::chrono::microseconds>(*value - dp));
         const auto ymd = ::date::year_month_day{dp};
 
-        // Timezone handling - always treat the value as UTC.
-        // It is assumed that the database timezone is set to UTC, too.
+        // Timezone handling - always treat the local value as UTC.
         std::ostringstream os;
-        os << ymd << ' ' << time;
+        os << ymd << ' ' << time << "+00";
         _handle->paramValues[index] = os.str();
         if (_handle->debug())
         {

--- a/include/sqlpp11/postgresql/serializer.h
+++ b/include/sqlpp11/postgresql/serializer.h
@@ -65,6 +65,13 @@ namespace sqlpp
     context << "TIMESTAMP WITH TIME ZONE '" << ymd << ' ' << time << "+00'";
     return context;
   }
+
+  template <typename Period>
+  postgresql::context_t& serialize(const time_of_day_operand<Period>& t, postgresql::context_t& context)
+  {
+    context << "TIME WITH TIME ZONE '" << ::date::make_time(t._t) << "+00'";
+    return context;
+  }
 }
 
 #endif

--- a/tests/postgresql/usage/TimeZone.cpp
+++ b/tests/postgresql/usage/TimeZone.cpp
@@ -131,7 +131,8 @@ int TimeZone(int, char*[])
 {
   namespace sql = sqlpp::postgresql;
 
-  auto dbc = sql::make_test_connection();
+  // We use a time zone with non-zero offset from UTC in order to catch serialization/parsing bugs
+  auto dbc = sql::make_test_connection("+1");
 
   dbc.execute("DROP TABLE IF EXISTS tabdatetime;");
   dbc.execute(

--- a/tests/postgresql/usage/make_test_connection.h
+++ b/tests/postgresql/usage/make_test_connection.h
@@ -51,7 +51,7 @@ namespace sqlpp
     }
 
     // Starts a connection and sets the time zone to UTC
-    inline ::sqlpp::postgresql::connection make_test_connection()
+    inline ::sqlpp::postgresql::connection make_test_connection(const std::string &tz = "UTC")
     {
       namespace sql = sqlpp::postgresql;
 
@@ -69,7 +69,7 @@ namespace sqlpp
         throw;
       }
 
-      db.execute(R"(SET TIME ZONE 'UTC';)");
+      db.execute("SET TIME ZONE " + tz + ";");
 
       return db;
     }


### PR DESCRIPTION
I changed slightly the PostgreSQL TimeZone test and made it setup a database session in the UTC+1 timezone instead of the default UTC timezone. This allowed it to find a few bugs that the UTC timezone was masking. So I prepared a PR with the fixes. More specifically this PR has the following changes:

- As mentioned above the TimeZone test is changed to use UTC+1 during the test.
- The serializaton of `time_of_day_operand` has been fixed. The previous PostgreSQL PR changed the parsing of "TIME WITH TIMEZONE" results so that their timezone was taken into an account, but did not fix the serialization. This PR fixes that. (The serialization of normal (non-prepared) time_point was fixed by the first PostgreSQL PR).
- The serialization of `time_point` for prepared statements has been fixed.
- The serialization of `time_of_day_operand` for prepared statements has been fixed.

This PR conflicts slightly with the other PR that fixes MySQL time handling. So once the MySQL PR is merged I will rebase this PR against the updated codebase.