### PR TITLE
Cleanup the code of the MySQL connector

### DIFF
--- a/include/sqlpp11/mysql/bind_result.h
+++ b/include/sqlpp11/mysql/bind_result.h
@@ -26,91 +26,21 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <iostream>
-#include <memory>
-#include <vector>
 #include <sqlpp11/chrono.h>
 #include <sqlpp11/exception.h>
+#include <sqlpp11/mysql/detail/prepared_statement_handle.h>
 #include <sqlpp11/mysql/sqlpp_mysql.h>
 
+#include <iostream>
 #ifdef _MSC_VER
 #include <iso646.h>
 #endif
+#include <memory>
 
 namespace sqlpp
 {
   namespace mysql
   {
-    namespace detail
-    {
-      struct result_meta_data_t
-      {
-        size_t index;
-        unsigned long bound_len;
-        my_bool bound_is_null;
-        my_bool bound_error;
-        std::vector<char> bound_text_buffer;  // also for blobs
-        const char** text_buffer;
-        size_t* len;
-        bool* is_null;
-      };
-
-      struct prepared_statement_handle_t
-      {
-        struct wrapped_bool
-        {
-          my_bool value;
-
-          wrapped_bool() : value(false)
-          {
-          }
-          wrapped_bool(bool v) : value(v)
-          {
-          }
-          wrapped_bool(const wrapped_bool&) = default;
-          wrapped_bool(wrapped_bool&&) = default;
-          wrapped_bool& operator=(const wrapped_bool&) = default;
-          wrapped_bool& operator=(wrapped_bool&&) = default;
-          ~wrapped_bool() = default;
-        };
-
-        MYSQL_STMT* mysql_stmt;
-        std::vector<MYSQL_BIND> stmt_params;
-        std::vector<MYSQL_TIME> stmt_date_time_param_buffer;
-        std::vector<wrapped_bool> stmt_param_is_null;  // my_bool is bool after 8.0, and vector<bool> is bad
-        std::vector<MYSQL_BIND> result_params;
-        std::vector<result_meta_data_t> result_param_meta_data;
-        bool debug;
-
-        prepared_statement_handle_t(MYSQL_STMT* stmt, size_t no_of_parameters, size_t no_of_columns, bool debug_)
-            : mysql_stmt(stmt),
-              stmt_params(no_of_parameters, MYSQL_BIND{}),
-              stmt_date_time_param_buffer(no_of_parameters, MYSQL_TIME{}),
-              stmt_param_is_null(no_of_parameters, false),
-              result_params(no_of_columns, MYSQL_BIND{}),
-              result_param_meta_data(no_of_columns, result_meta_data_t{}),
-              debug(debug_)
-        {
-        }
-
-        prepared_statement_handle_t(const prepared_statement_handle_t&) = delete;
-        prepared_statement_handle_t(prepared_statement_handle_t&&) = default;
-        prepared_statement_handle_t& operator=(const prepared_statement_handle_t&) = delete;
-        prepared_statement_handle_t& operator=(prepared_statement_handle_t&&) = default;
-
-        ~prepared_statement_handle_t()
-        {
-          if (mysql_stmt)
-            mysql_stmt_close(mysql_stmt);
-        }
-
-        bool operator!() const
-        {
-          return !mysql_stmt;
-        }
-      };
-    }  // namespace detail
-
     class bind_result_t
     {
       std::shared_ptr<detail::prepared_statement_handle_t> _handle;

--- a/include/sqlpp11/mysql/char_result.h
+++ b/include/sqlpp11/mysql/char_result.h
@@ -42,9 +42,9 @@ namespace sqlpp
   {
     namespace detail
     {
-      inline auto check_first_digit(const char* text, bool digitFlag) -> bool
+      inline auto check_first_digit(const char* text, bool digit_flag) -> bool
       {
-        if (digitFlag)
+        if (digit_flag)
         {
           if (not std::isdigit(*text))
           {
@@ -63,9 +63,9 @@ namespace sqlpp
 
       inline auto check_date_digits(const char* text) -> bool
       {
-        for (const auto digitFlag : {true, true, true, true, false, true, true, false, true, true})  // YYYY-MM-DD
+        for (const auto digit_flag : {true, true, true, true, false, true, true, false, true, true})  // YYYY-MM-DD
         {
-          if (not check_first_digit(text, digitFlag))
+          if (not check_first_digit(text, digit_flag))
             return false;
           ++text;
         }
@@ -74,9 +74,9 @@ namespace sqlpp
 
       inline auto check_time_digits(const char* text) -> bool
       {
-        for (const auto digitFlag : {true, true, false, true, true, false, true, true}) // hh:mm:ss
+        for (const auto digit_flag : {true, true, false, true, true, false, true, true}) // hh:mm:ss
         {
-          if (not check_first_digit(text, digitFlag))
+          if (not check_first_digit(text, digit_flag))
             return false;
           ++text;
         }

--- a/include/sqlpp11/mysql/char_result.h
+++ b/include/sqlpp11/mysql/char_result.h
@@ -32,6 +32,7 @@
 #include <memory>
 #include <sqlpp11/chrono.h>
 #include <sqlpp11/exception.h>
+#include <sqlpp11/mysql/detail/result_handle.h>
 #include <sqlpp11/mysql/sqlpp_mysql.h>
 #include <sqlpp11/mysql/char_result_row.h>
 
@@ -41,32 +42,6 @@ namespace sqlpp
   {
     namespace detail
     {
-      struct result_handle
-      {
-        MYSQL_RES* mysql_res;
-        bool debug;
-
-        result_handle(MYSQL_RES* res, bool debug_) : mysql_res(res), debug(debug_)
-        {
-        }
-
-        result_handle(const result_handle&) = delete;
-        result_handle(result_handle&&) = default;
-        result_handle& operator=(const result_handle&) = delete;
-        result_handle& operator=(result_handle&&) = default;
-
-        ~result_handle()
-        {
-          if (mysql_res)
-            mysql_free_result(mysql_res);
-        }
-
-        bool operator!() const
-        {
-          return !mysql_res;
-        }
-      };
-
       inline auto check_first_digit(const char* text, bool digitFlag) -> bool
       {
         if (digitFlag)

--- a/include/sqlpp11/mysql/connection.h
+++ b/include/sqlpp11/mysql/connection.h
@@ -155,12 +155,12 @@ namespace sqlpp
     // Forward declaration
     class connection_base;
 
-    struct serializer_t
+    struct context_t
     {
-      serializer_t(const connection_base& db) : _db(db)
+      context_t(const connection_base& db) : _db(db)
       {
       }
-      serializer_t(const connection_base&&) = delete;
+      context_t(const connection_base&&) = delete;
 
       template <typename T>
       std::ostream& operator<<(T t)
@@ -179,9 +179,9 @@ namespace sqlpp
       sqlpp::detail::float_safe_ostringstream _os;
     };
 
-    std::integral_constant<char, '`'> get_quote_left(const serializer_t&);
+    std::integral_constant<char, '`'> get_quote_left(const context_t&);
 
-    std::integral_constant<char, '`'> get_quote_right(const serializer_t&);
+    std::integral_constant<char, '`'> get_quote_right(const context_t&);
 
     class connection_base : public sqlpp::connection
     {
@@ -260,7 +260,7 @@ namespace sqlpp
       using _handle_ptr_t = std::unique_ptr<_handle_t>;
 
       using _prepared_statement_t = ::sqlpp::mysql::prepared_statement_t;
-      using _context_t = serializer_t;
+      using _context_t = context_t;
       using _serializer_context_t = _context_t;
       using _interpreter_context_t = _context_t;
 
@@ -514,7 +514,7 @@ namespace sqlpp
     };
 
     // Method definition moved outside of class because it needs connection_base
-    inline std::string serializer_t::escape(std::string arg)
+    inline std::string context_t::escape(std::string arg)
     {
       return _db.escape(arg);
     }

--- a/include/sqlpp11/mysql/connection.h
+++ b/include/sqlpp11/mysql/connection.h
@@ -48,9 +48,9 @@ namespace sqlpp
   {
     namespace detail
     {
-      struct MySqlThreadInitializer
+      struct mysql_thread_initializer
       {
-        MySqlThreadInitializer()
+        mysql_thread_initializer()
         {
           if (!mysql_thread_safe())
           {
@@ -59,7 +59,7 @@ namespace sqlpp
           mysql_thread_init();
         }
 
-        ~MySqlThreadInitializer()
+        ~mysql_thread_initializer()
         {
           mysql_thread_end();
         }
@@ -67,7 +67,7 @@ namespace sqlpp
 
       inline void thread_init()
       {
-        thread_local MySqlThreadInitializer threadInitializer;
+        thread_local mysql_thread_initializer thread_initializer;
       }
 
       inline void execute_statement(std::unique_ptr<connection_handle>& handle, const std::string& statement)

--- a/include/sqlpp11/mysql/connection.h
+++ b/include/sqlpp11/mysql/connection.h
@@ -168,7 +168,7 @@ namespace sqlpp
         return _os << t;
       }
 
-      std::string escape(std::string arg);
+      std::string escape(const std::string& arg) const;
 
       std::string str() const
       {
@@ -514,7 +514,7 @@ namespace sqlpp
     };
 
     // Method definition moved outside of class because it needs connection_base
-    inline std::string context_t::escape(std::string arg)
+    inline std::string context_t::escape(const std::string& arg) const
     {
       return _db.escape(arg);
     }

--- a/include/sqlpp11/mysql/connection.h
+++ b/include/sqlpp11/mysql/connection.h
@@ -70,7 +70,7 @@ namespace sqlpp
         thread_local MySqlThreadInitializer threadInitializer;
       }
 
-      inline void execute_statement(std::unique_ptr<connection_handle_t>& handle, const std::string& statement)
+      inline void execute_statement(std::unique_ptr<connection_handle>& handle, const std::string& statement)
       {
         thread_init();
 
@@ -105,7 +105,7 @@ namespace sqlpp
         }
       }
 
-      inline std::shared_ptr<detail::prepared_statement_handle_t> prepare_statement(std::unique_ptr<connection_handle_t>& handle,
+      inline std::shared_ptr<detail::prepared_statement_handle_t> prepare_statement(std::unique_ptr<connection_handle>& handle,
                                                                              const std::string& statement,
                                                                              size_t no_of_parameters,
                                                                              size_t no_of_columns)
@@ -256,7 +256,7 @@ namespace sqlpp
       using _connection_base_t = connection_base;
       using _config_t = connection_config;
       using _config_ptr_t = std::shared_ptr<const _config_t>;
-      using _handle_t = detail::connection_handle_t;
+      using _handle_t = detail::connection_handle;
       using _handle_ptr_t = std::unique_ptr<_handle_t>;
 
       using _prepared_statement_t = ::sqlpp::mysql::prepared_statement_t;

--- a/include/sqlpp11/mysql/detail/connection_handle.h
+++ b/include/sqlpp11/mysql/detail/connection_handle.h
@@ -70,12 +70,12 @@ namespace sqlpp
         mysql_close(mysql);
       }
 
-      struct connection_handle_t
+      struct connection_handle
       {
         std::shared_ptr<const connection_config> config;
         std::unique_ptr<MYSQL, void (*)(MYSQL*)> mysql;
 
-        connection_handle_t(const std::shared_ptr<const connection_config>& conf) :
+        connection_handle(const std::shared_ptr<const connection_config>& conf) :
           config(conf),
           mysql(mysql_init(nullptr), handle_cleanup)
         {
@@ -96,10 +96,10 @@ namespace sqlpp
           connect(native_handle(), *config);
         }
 
-        connection_handle_t(const connection_handle_t&) = delete;
-        connection_handle_t(connection_handle_t&&) = default;
-        connection_handle_t& operator=(const connection_handle_t&) = delete;
-        connection_handle_t& operator=(connection_handle_t&&) = default;
+        connection_handle(const connection_handle&) = delete;
+        connection_handle(connection_handle&&) = default;
+        connection_handle& operator=(const connection_handle&) = delete;
+        connection_handle& operator=(connection_handle&&) = default;
 
         MYSQL* native_handle() const
         {

--- a/include/sqlpp11/mysql/detail/connection_handle.h
+++ b/include/sqlpp11/mysql/detail/connection_handle.h
@@ -1,0 +1,122 @@
+#pragma once
+
+/*
+ * Copyright (c) 2013 - 2017, Roland Bock
+ * Copyright (c) 2023, Vesselin Atanasov
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *   Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *   Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sqlpp11/mysql/connection_config.h>
+#include <sqlpp11/mysql/sqlpp_mysql.h>
+
+#include <memory>
+
+namespace sqlpp
+{
+  namespace mysql
+  {
+    namespace detail
+    {
+      inline void connect(MYSQL* mysql, const connection_config& config)
+      {
+        if (config.connect_timeout_seconds != 0 &&
+            mysql_options(mysql, MYSQL_OPT_CONNECT_TIMEOUT, &config.connect_timeout_seconds))
+        {
+          throw sqlpp::exception("MySQL: could not set option MYSQL_OPT_CONNECT_TIMEOUT");
+        }
+
+        if (!mysql_real_connect(mysql, config.host.empty() ? nullptr : config.host.c_str(),
+                                config.user.empty() ? nullptr : config.user.c_str(),
+                                config.password.empty() ? nullptr : config.password.c_str(), nullptr, config.port,
+                                config.unix_socket.empty() ? nullptr : config.unix_socket.c_str(), config.client_flag))
+        {
+          throw sqlpp::exception("MySQL: could not connect to server: " + std::string(mysql_error(mysql)));
+        }
+
+        if (mysql_set_character_set(mysql, config.charset.c_str()))
+        {
+          throw sqlpp::exception("MySQL error: can't set character set " + config.charset);
+        }
+
+        if (not config.database.empty() and mysql_select_db(mysql, config.database.c_str()))
+        {
+          throw sqlpp::exception("MySQL error: can't select database '" + config.database + "'");
+        }
+      }
+
+      inline void handle_cleanup(MYSQL* mysql)
+      {
+        mysql_close(mysql);
+      }
+
+      struct connection_handle_t
+      {
+        std::shared_ptr<const connection_config> config;
+        std::unique_ptr<MYSQL, void (*)(MYSQL*)> mysql;
+
+        connection_handle_t(const std::shared_ptr<const connection_config>& conf) :
+          config(conf),
+          mysql(mysql_init(nullptr), handle_cleanup)
+        {
+          if (not mysql)
+          {
+            throw sqlpp::exception("MySQL: could not init mysql data structure");
+          }
+
+          if (config->auto_reconnect)
+          {
+            my_bool my_true = true;
+            if (mysql_options(native_handle(), MYSQL_OPT_RECONNECT, &my_true))
+            {
+              throw sqlpp::exception("MySQL: could not set option MYSQL_OPT_RECONNECT");
+            }
+          }
+
+          connect(native_handle(), *config);
+        }
+
+        connection_handle_t(const connection_handle_t&) = delete;
+        connection_handle_t(connection_handle_t&&) = default;
+        connection_handle_t& operator=(const connection_handle_t&) = delete;
+        connection_handle_t& operator=(connection_handle_t&&) = default;
+
+        MYSQL* native_handle() const
+        {
+          return mysql.get();
+        }
+
+        bool check_connection() const
+        {
+          auto nh = native_handle();
+          return nh && (mysql_ping(nh) == 0);
+        }
+
+        void reconnect()
+        {
+          connect(native_handle(), *config);
+        }
+      };
+    }  // namespace detail
+  }  // namespace mysql
+}  // namespace sqlpp

--- a/include/sqlpp11/mysql/detail/connection_handle.h
+++ b/include/sqlpp11/mysql/detail/connection_handle.h
@@ -65,11 +65,6 @@ namespace sqlpp
         }
       }
 
-      inline void handle_cleanup(MYSQL* mysql)
-      {
-        mysql_close(mysql);
-      }
-
       struct connection_handle
       {
         std::shared_ptr<const connection_config> config;
@@ -77,7 +72,7 @@ namespace sqlpp
 
         connection_handle(const std::shared_ptr<const connection_config>& conf) :
           config(conf),
-          mysql(mysql_init(nullptr), handle_cleanup)
+          mysql(mysql_init(nullptr), mysql_close)
         {
           if (not mysql)
           {

--- a/include/sqlpp11/mysql/detail/prepared_statement_handle.h
+++ b/include/sqlpp11/mysql/detail/prepared_statement_handle.h
@@ -1,0 +1,107 @@
+#pragma once
+
+/*
+ * Copyright (c) 2013 - 2015, Roland Bock
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *   Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *   Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sqlpp11/mysql/sqlpp_mysql.h>
+
+#include <vector>
+
+namespace sqlpp
+{
+  namespace mysql
+  {
+    namespace detail
+    {
+      struct result_meta_data_t
+      {
+        size_t index;
+        unsigned long bound_len;
+        my_bool bound_is_null;
+        my_bool bound_error;
+        std::vector<char> bound_text_buffer;  // also for blobs
+        const char** text_buffer;
+        size_t* len;
+        bool* is_null;
+      };
+
+      struct prepared_statement_handle_t
+      {
+        struct wrapped_bool
+        {
+          my_bool value;
+
+          wrapped_bool() : value(false)
+          {
+          }
+          wrapped_bool(bool v) : value(v)
+          {
+          }
+          wrapped_bool(const wrapped_bool&) = default;
+          wrapped_bool(wrapped_bool&&) = default;
+          wrapped_bool& operator=(const wrapped_bool&) = default;
+          wrapped_bool& operator=(wrapped_bool&&) = default;
+          ~wrapped_bool() = default;
+        };
+
+        MYSQL_STMT* mysql_stmt;
+        std::vector<MYSQL_BIND> stmt_params;
+        std::vector<MYSQL_TIME> stmt_date_time_param_buffer;
+        std::vector<wrapped_bool> stmt_param_is_null;  // my_bool is bool after 8.0, and vector<bool> is bad
+        std::vector<MYSQL_BIND> result_params;
+        std::vector<result_meta_data_t> result_param_meta_data;
+        bool debug;
+
+        prepared_statement_handle_t(MYSQL_STMT* stmt, size_t no_of_parameters, size_t no_of_columns, bool debug_)
+            : mysql_stmt(stmt),
+              stmt_params(no_of_parameters, MYSQL_BIND{}),
+              stmt_date_time_param_buffer(no_of_parameters, MYSQL_TIME{}),
+              stmt_param_is_null(no_of_parameters, false),
+              result_params(no_of_columns, MYSQL_BIND{}),
+              result_param_meta_data(no_of_columns, result_meta_data_t{}),
+              debug(debug_)
+        {
+        }
+
+        prepared_statement_handle_t(const prepared_statement_handle_t&) = delete;
+        prepared_statement_handle_t(prepared_statement_handle_t&&) = default;
+        prepared_statement_handle_t& operator=(const prepared_statement_handle_t&) = delete;
+        prepared_statement_handle_t& operator=(prepared_statement_handle_t&&) = default;
+
+        ~prepared_statement_handle_t()
+        {
+          if (mysql_stmt)
+            mysql_stmt_close(mysql_stmt);
+        }
+
+        bool operator!() const
+        {
+          return !mysql_stmt;
+        }
+      };
+    }  // namespace detail
+  }  // namespace mysql
+}  // namespace sqlpp

--- a/include/sqlpp11/mysql/detail/result_handle.h
+++ b/include/sqlpp11/mysql/detail/result_handle.h
@@ -1,0 +1,62 @@
+#pragma once
+
+/*
+ * Copyright (c) 2013 - 2015, Roland Bock
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *   Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *   Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace sqlpp
+{
+  namespace mysql
+  {
+    namespace detail
+    {
+      struct result_handle
+      {
+        MYSQL_RES* mysql_res;
+        bool debug;
+
+        result_handle(MYSQL_RES* res, bool debug_) : mysql_res(res), debug(debug_)
+        {
+        }
+
+        result_handle(const result_handle&) = delete;
+        result_handle(result_handle&&) = default;
+        result_handle& operator=(const result_handle&) = delete;
+        result_handle& operator=(result_handle&&) = default;
+
+        ~result_handle()
+        {
+          if (mysql_res)
+            mysql_free_result(mysql_res);
+        }
+
+        bool operator!() const
+        {
+          return !mysql_res;
+        }
+      };
+    }  // namespace detail
+  }  // namespace mysql
+}  // namespace sqlpp

--- a/include/sqlpp11/mysql/prepared_statement.h
+++ b/include/sqlpp11/mysql/prepared_statement.h
@@ -33,7 +33,6 @@
 #include <memory>
 #include <iostream>
 #include <string>
-#include <vector>
 #include <sqlpp11/chrono.h>
 
 namespace sqlpp

--- a/include/sqlpp11/mysql/serializer.h
+++ b/include/sqlpp11/mysql/serializer.h
@@ -32,17 +32,17 @@
 namespace sqlpp
 {
   template <typename First, typename... Args>
-  mysql::serializer_t& serialize(const concat_t<First, Args...>& t, mysql::serializer_t& context)
+  mysql::context_t& serialize(const concat_t<First, Args...>& t, mysql::context_t& ctx)
   {
-    context << "CONCAT(";
-    interpret_tuple(t._args, ',', context);
-    context << ')';
-    return context;
+    ctx << "CONCAT(";
+    interpret_tuple(t._args, ',', ctx);
+    ctx << ')';
+    return ctx;
   }
 
-  inline mysql::serializer_t& serialize(const insert_default_values_data_t&, mysql::serializer_t& context)
+  inline mysql::context_t& serialize(const insert_default_values_data_t&, mysql::context_t& ctx)
   {
-    context << " () VALUES()";
-    return context;
+    ctx << " () VALUES()";
+    return ctx;
   }
 }

--- a/tests/mysql/serialize/compare.h
+++ b/tests/mysql/serialize/compare.h
@@ -60,7 +60,7 @@ namespace
     }
 
     sqlpp::mysql::connection connection{config};
-    sqlpp::mysql::serializer_t printer{connection};
+    sqlpp::mysql::context_t printer{connection};
 
     const auto result = serialize(expr, printer).str();
 


### PR DESCRIPTION
OK, I updated the PR based on our discussion and I think it is ready for a review.

~~I mentioned my concern regarding the renaming of the types ending in _t here
https://github.com/rbock/sqlpp11/issues/500#issuecomment-1661392856
So it probably makes sense to postpone the merging of this PR until it is clear what to do with the renaming of these types.~~

This PR cleans up the code of the MySQL connector as per our discussion here
https://github.com/rbock/sqlpp11/issues/500#issuecomment-1659571760

The PR makes the following changes to the MySQL connector:

1. The code for the classes `connection_handle`, `prepared_statement_handle` and `result_handle.h` are moved to separate files in the 
`include/sqlpp11/mysql/detail/` directory.
~~2. All class and struct type names ending in `_t` have that suffix removed from their names. In some cases this caused some local variables and/or function parameters to be renamed in order avoid confusion and/or name clashes.~~
2. `sqlpp::mysql::connection_handle_t` has been renamed to `sqlpp::mysql::connection_handle` as the other two connectors (PostgreSQL and SQLite3) have `connection_handle` without the `_t` suffix.
3. `sqlpp::mysql::serializer_t` has been renamed to `sqlpp::mysql::context_t`
4. Const qualifier has been added to `sqlpp::mysql::context::escape()` and its parameter has been changed from `std::string` to `const std::string&`.
~~5. Old-style assignment-style parentheses-style initialization has been replaced with brace-style initialization. The only place where assignment-style initialization remains is `auto var = {value}` where C++11 has problems.~~
6. There were several variables and one helper class using CamelCase. Those were renamed to snake_case as the project as a whole is using snake_case.

After making the changes the project was built with tests for the MySQL, PostgreSQL and SQLite3 connectors and all tests passed successfully.