### PR TITLE
Use brace-style initialization in the MySQL connector code

### DIFF
--- a/include/sqlpp11/mysql/bind_result.h
+++ b/include/sqlpp11/mysql/bind_result.h
@@ -44,11 +44,11 @@ namespace sqlpp
     class bind_result_t
     {
       std::shared_ptr<detail::prepared_statement_handle_t> _handle;
-      void* _result_row_address = nullptr;
+      void* _result_row_address{nullptr};
 
     public:
       bind_result_t() = default;
-      bind_result_t(const std::shared_ptr<detail::prepared_statement_handle_t>& handle) : _handle(handle)
+      bind_result_t(const std::shared_ptr<detail::prepared_statement_handle_t>& handle) : _handle{handle}
       {
         if (_handle and _handle->debug)
           std::cerr << "MySQL debug: Constructing bind result, using handle at " << _handle.get() << std::endl;
@@ -109,12 +109,12 @@ namespace sqlpp
           std::cerr << "MySQL debug: binding boolean result " << static_cast<void*>(value) << " at index: " << index
                     << std::endl;
 
-        detail::result_meta_data_t& meta_data = _handle->result_param_meta_data[index];
+        detail::result_meta_data_t& meta_data{_handle->result_param_meta_data[index]};
         meta_data.index = index;
         meta_data.len = nullptr;
         meta_data.is_null = is_null;
 
-        MYSQL_BIND& param = _handle->result_params[index];
+        MYSQL_BIND& param{_handle->result_params[index]};
         param.buffer_type = MYSQL_TYPE_TINY;
         param.buffer = value;
         param.buffer_length = sizeof(*value);
@@ -130,12 +130,12 @@ namespace sqlpp
           std::cerr << "MySQL debug: binding integral result " << static_cast<void*>(value) << " at index: " << index
                     << std::endl;
 
-        detail::result_meta_data_t& meta_data = _handle->result_param_meta_data[index];
+        detail::result_meta_data_t& meta_data{_handle->result_param_meta_data[index]};
         meta_data.index = index;
         meta_data.len = nullptr;
         meta_data.is_null = is_null;
 
-        MYSQL_BIND& param = _handle->result_params[index];
+        MYSQL_BIND& param{_handle->result_params[index]};
         param.buffer_type = MYSQL_TYPE_LONGLONG;
         param.buffer = value;
         param.buffer_length = sizeof(*value);
@@ -151,12 +151,12 @@ namespace sqlpp
           std::cerr << "MySQL debug: binding unsigned integral result " << static_cast<void*>(value)
                     << " at index: " << index << std::endl;
 
-        detail::result_meta_data_t& meta_data = _handle->result_param_meta_data[index];
+        detail::result_meta_data_t& meta_data{_handle->result_param_meta_data[index]};
         meta_data.index = index;
         meta_data.len = nullptr;
         meta_data.is_null = is_null;
 
-        MYSQL_BIND& param = _handle->result_params[index];
+        MYSQL_BIND& param{_handle->result_params[index]};
         param.buffer_type = MYSQL_TYPE_LONGLONG;
         param.buffer = value;
         param.buffer_length = sizeof(*value);
@@ -172,12 +172,12 @@ namespace sqlpp
           std::cerr << "MySQL debug: binding floating point result " << static_cast<void*>(value)
                     << " at index: " << index << std::endl;
 
-        detail::result_meta_data_t& meta_data = _handle->result_param_meta_data[index];
+        detail::result_meta_data_t& meta_data{_handle->result_param_meta_data[index]};
         meta_data.index = index;
         meta_data.len = nullptr;
         meta_data.is_null = is_null;
 
-        MYSQL_BIND& param = _handle->result_params[index];
+        MYSQL_BIND& param{_handle->result_params[index]};
         param.buffer_type = MYSQL_TYPE_DOUBLE;
         param.buffer = value;
         param.buffer_length = sizeof(*value);
@@ -193,7 +193,7 @@ namespace sqlpp
           std::cerr << "MySQL debug: binding text result " << static_cast<const void*>(*value) << " at index: " << index
                     << std::endl;
 
-        detail::result_meta_data_t& meta_data = _handle->result_param_meta_data[index];
+        detail::result_meta_data_t& meta_data{_handle->result_param_meta_data[index]};
         meta_data.index = index;
         meta_data.len = len;
         meta_data.is_null = nullptr;
@@ -201,7 +201,7 @@ namespace sqlpp
         if (meta_data.bound_text_buffer.empty())
           meta_data.bound_text_buffer.resize(8);
 
-        MYSQL_BIND& param = _handle->result_params[index];
+        MYSQL_BIND& param{_handle->result_params[index]};
         param.buffer_type = MYSQL_TYPE_STRING;
         param.buffer = meta_data.bound_text_buffer.data();
         param.buffer_length = meta_data.bound_text_buffer.size();
@@ -216,7 +216,7 @@ namespace sqlpp
           std::cerr << "MySQL debug: binding text result " << static_cast<const void*>(*value) << " at index: " << index
                     << std::endl;
 
-        detail::result_meta_data_t& meta_data = _handle->result_param_meta_data[index];
+        detail::result_meta_data_t& meta_data{_handle->result_param_meta_data[index]};
         meta_data.index = index;
         meta_data.len = len;
         meta_data.is_null = nullptr;
@@ -224,7 +224,7 @@ namespace sqlpp
         if (meta_data.bound_text_buffer.empty())
           meta_data.bound_text_buffer.resize(8);
 
-        MYSQL_BIND& param = _handle->result_params[index];
+        MYSQL_BIND& param{_handle->result_params[index]};
         param.buffer_type = MYSQL_TYPE_BLOB;
         param.buffer = meta_data.bound_text_buffer.data();
         param.buffer_length = meta_data.bound_text_buffer.size();
@@ -240,14 +240,14 @@ namespace sqlpp
           std::cerr << "MySQL debug: binding date result " << static_cast<void*>(value) << " at index: " << index
                     << std::endl;
 
-        detail::result_meta_data_t& meta_data = _handle->result_param_meta_data[index];
+        detail::result_meta_data_t& meta_data{_handle->result_param_meta_data[index]};
         meta_data.index = index;
         meta_data.len = nullptr;
         meta_data.is_null = is_null;
         meta_data.text_buffer = nullptr;
         meta_data.bound_text_buffer.resize(sizeof(MYSQL_TIME));
 
-        MYSQL_BIND& param = _handle->result_params[index];
+        MYSQL_BIND& param{_handle->result_params[index]};
         param.buffer_type = MYSQL_TYPE_DATE;
         param.buffer = meta_data.bound_text_buffer.data();
         param.buffer_length = meta_data.bound_text_buffer.size();
@@ -263,14 +263,14 @@ namespace sqlpp
           std::cerr << "MySQL debug: binding date time result " << static_cast<void*>(value) << " at index: " << index
                     << std::endl;
 
-        detail::result_meta_data_t& meta_data = _handle->result_param_meta_data[index];
+        detail::result_meta_data_t& meta_data{_handle->result_param_meta_data[index]};
         meta_data.index = index;
         meta_data.len = nullptr;
         meta_data.is_null = is_null;
         meta_data.text_buffer = nullptr;
         meta_data.bound_text_buffer.resize(sizeof(MYSQL_TIME));
 
-        MYSQL_BIND& param = _handle->result_params[index];
+        MYSQL_BIND& param{_handle->result_params[index]};
         param.buffer_type = MYSQL_TYPE_DATETIME;
         param.buffer = meta_data.bound_text_buffer.data();
         param.buffer_length = meta_data.bound_text_buffer.size();
@@ -306,7 +306,7 @@ namespace sqlpp
           const auto& dt =
               *reinterpret_cast<const MYSQL_TIME*>(_handle->result_param_meta_data[index].bound_text_buffer.data());
           if (dt.year > std::numeric_limits<int>::max())
-            throw sqlpp::exception("cannot read year from db: " + std::to_string(dt.year));
+            throw sqlpp::exception{"cannot read year from db: " + std::to_string(dt.year)};
           *is_null = false;
           *value = ::date::year(static_cast<int>(dt.year)) / ::date::month(dt.month) / ::date::day(dt.day);
         }
@@ -323,7 +323,7 @@ namespace sqlpp
           const auto& dt =
               *reinterpret_cast<const MYSQL_TIME*>(_handle->result_param_meta_data[index].bound_text_buffer.data());
           if (dt.year > std::numeric_limits<int>::max())
-            throw sqlpp::exception("cannot read year from db: " + std::to_string(dt.year));
+            throw sqlpp::exception{"cannot read year from db: " + std::to_string(dt.year)};
           *is_null = false;
           *value = ::sqlpp::chrono::day_point(::date::year(static_cast<int>(dt.year)) / ::date::month(dt.month) / ::date::day(dt.day)) +
                    std::chrono::hours(dt.hour) + std::chrono::minutes(dt.minute) + std::chrono::seconds(dt.second) +
@@ -339,8 +339,8 @@ namespace sqlpp
 
         if (mysql_stmt_bind_result(_handle->mysql_stmt, _handle->result_params.data()))
         {
-          throw sqlpp::exception(std::string("MySQL: mysql_stmt_bind_result: ") +
-                                 mysql_stmt_error(_handle->mysql_stmt));
+          throw sqlpp::exception{std::string{"MySQL: mysql_stmt_bind_result: "} +
+                                 mysql_stmt_error(_handle->mysql_stmt)};
         }
       }
 
@@ -356,7 +356,7 @@ namespace sqlpp
           case 0:
           case MYSQL_DATA_TRUNCATED:
           {
-            bool need_to_rebind = false;
+            bool need_to_rebind{false};
             for (auto& r : _handle->result_param_meta_data)
             {
               if (r.len)
@@ -375,17 +375,17 @@ namespace sqlpp
                                 << " at index " << r.index << " for handle at " << _handle.get() << std::endl;
                     need_to_rebind = true;
                     r.bound_text_buffer.resize(r.bound_len);
-                    MYSQL_BIND& param = _handle->result_params[r.index];
+                    MYSQL_BIND& param{_handle->result_params[r.index]};
                     param.buffer = r.bound_text_buffer.data();
                     param.buffer_length = r.bound_text_buffer.size();
 
                     auto err =
                         mysql_stmt_fetch_column(_handle->mysql_stmt, &param, static_cast<unsigned int>(r.index), 0);
                     if (err)
-                      throw sqlpp::exception(std::string("MySQL: Fetch column after reallocate failed: ") +
+                      throw sqlpp::exception{std::string{"MySQL: Fetch column after reallocate failed: "} +
                                              "error-code: " + std::to_string(err) +
                                              ", stmt-error: " + mysql_stmt_error(_handle->mysql_stmt) +
-                                             ", stmt-errno: " + std::to_string(mysql_stmt_errno(_handle->mysql_stmt)));
+                                             ", stmt-errno: " + std::to_string(mysql_stmt_errno(_handle->mysql_stmt))};
                   }
                   *r.text_buffer = r.bound_text_buffer.data();
                   if (_handle->debug)
@@ -403,12 +403,12 @@ namespace sqlpp
           }
             return true;
           case 1:
-            throw sqlpp::exception(std::string("MySQL: Could not fetch next result: ") +
-                                   mysql_stmt_error(_handle->mysql_stmt));
+            throw sqlpp::exception{std::string{"MySQL: Could not fetch next result: "} +
+                                   mysql_stmt_error(_handle->mysql_stmt)};
           case MYSQL_NO_DATA:
             return false;
           default:
-            throw sqlpp::exception("MySQL: Unexpected return value for mysql_stmt_fetch()");
+            throw sqlpp::exception{"MySQL: Unexpected return value for mysql_stmt_fetch()"};
         }
       }
     };

--- a/include/sqlpp11/mysql/char_result.h
+++ b/include/sqlpp11/mysql/char_result.h
@@ -91,10 +91,10 @@ namespace sqlpp
 
     public:
       char_result_t() = default;
-      char_result_t(std::unique_ptr<detail::result_handle>&& handle) : _handle(std::move(handle))
+      char_result_t(std::unique_ptr<detail::result_handle>&& handle) : _handle{std::move(handle)}
       {
         if (_invalid())
-          throw sqlpp::exception("MySQL: Constructing char_result without valid handle");
+          throw sqlpp::exception{"MySQL: Constructing char_result without valid handle"};
 
         if (_handle->debug)
           std::cerr << "MySQL debug: Constructing result, using handle at " << _handle.get() << std::endl;
@@ -167,14 +167,14 @@ namespace sqlpp
 
       void _bind_blob_result(size_t index, const uint8_t** value, size_t* len)
       {
-        bool is_null = (_char_result_row.data == nullptr or _char_result_row.data[index] == nullptr);
+        bool is_null{_char_result_row.data == nullptr or _char_result_row.data[index] == nullptr};
         *value = (uint8_t*)(is_null ? nullptr : _char_result_row.data[index]);
         *len = (is_null ? 0 : _char_result_row.len[index]);
       }
 
       void _bind_text_result(size_t index, const char** value, size_t* len)
       {
-        bool is_null = (_char_result_row.data == nullptr or _char_result_row.data[index] == nullptr);
+        bool is_null{_char_result_row.data == nullptr or _char_result_row.data[index] == nullptr};
         *value = (is_null ? nullptr : _char_result_row.data[index]);
         *len = (is_null ? 0 : _char_result_row.len[index]);
       }

--- a/include/sqlpp11/mysql/connection.h
+++ b/include/sqlpp11/mysql/connection.h
@@ -54,7 +54,7 @@ namespace sqlpp
         {
           if (!mysql_thread_safe())
           {
-            throw sqlpp::exception("MySQL error: Operating on a non-threadsafe client");
+            throw sqlpp::exception{"MySQL error: Operating on a non-threadsafe client"};
           }
           mysql_thread_init();
         }
@@ -79,9 +79,9 @@ namespace sqlpp
 
         if (mysql_query(handle->native_handle(), statement.c_str()))
         {
-          throw sqlpp::exception(
-              "MySQL error: Could not execute MySQL-statement: " + std::string(mysql_error(handle->native_handle())) +
-              " (statement was >>" + statement + "<<\n");
+          throw sqlpp::exception{
+              "MySQL error: Could not execute MySQL-statement: " + std::string{mysql_error(handle->native_handle())} +
+              " (statement was >>" + statement + "<<\n"};
         }
       }
 
@@ -94,14 +94,14 @@ namespace sqlpp
 
         if (mysql_stmt_bind_param(prepared_statement.mysql_stmt, prepared_statement.stmt_params.data()))
         {
-          throw sqlpp::exception(std::string("MySQL error: Could not bind parameters to statement") +
-                                 mysql_stmt_error(prepared_statement.mysql_stmt));
+          throw sqlpp::exception{std::string{"MySQL error: Could not bind parameters to statement"} +
+                                 mysql_stmt_error(prepared_statement.mysql_stmt)};
         }
 
         if (mysql_stmt_execute(prepared_statement.mysql_stmt))
         {
-          throw sqlpp::exception(std::string("MySQL error: Could not execute prepared statement: ") +
-                                 mysql_stmt_error(prepared_statement.mysql_stmt));
+          throw sqlpp::exception{std::string{"MySQL error: Could not execute prepared statement: "} +
+                                 mysql_stmt_error(prepared_statement.mysql_stmt)};
         }
       }
 
@@ -119,13 +119,13 @@ namespace sqlpp
             mysql_stmt_init(handle->native_handle()), no_of_parameters, no_of_columns, handle->config->debug);
         if (not prepared_statement)
         {
-          throw sqlpp::exception("MySQL error: Could not allocate prepared statement\n");
+          throw sqlpp::exception{"MySQL error: Could not allocate prepared statement\n"};
         }
         if (mysql_stmt_prepare(prepared_statement->mysql_stmt, statement.data(), statement.size()))
         {
-          throw sqlpp::exception(
-              "MySQL error: Could not prepare statement: " + std::string(mysql_error(handle->native_handle())) +
-              " (statement was >>" + statement + "<<\n");
+          throw sqlpp::exception{
+              "MySQL error: Could not prepare statement: " + std::string{mysql_error(handle->native_handle())} +
+              " (statement was >>" + statement + "<<\n"};
         }
 
         return prepared_statement;
@@ -157,7 +157,7 @@ namespace sqlpp
 
     struct context_t
     {
-      context_t(const connection_base& db) : _db(db)
+      context_t(const connection_base& db) : _db{db}
       {
       }
       context_t(const connection_base&&) = delete;
@@ -186,7 +186,7 @@ namespace sqlpp
     class connection_base : public sqlpp::connection
     {
     private:
-      bool _transaction_active = false;
+      bool _transaction_active{false};
 
       // direct execution
       char_result_t select_impl(const std::string& statement)
@@ -196,8 +196,8 @@ namespace sqlpp
             new detail::result_handle(mysql_store_result(_handle->native_handle()), _handle->config->debug));
         if (!*result_handle)
         {
-          throw sqlpp::exception("MySQL error: Could not store result set: " +
-                                 std::string(mysql_error(_handle->native_handle())));
+          throw sqlpp::exception{"MySQL error: Could not store result set: " +
+                                 std::string{mysql_error(_handle->native_handle())}};
         }
 
         return {std::move(result_handle)};
@@ -304,7 +304,7 @@ namespace sqlpp
       template <typename Select>
       char_result_t select(const Select& s)
       {
-        _context_t context(*this);
+        _context_t context{*this};
         serialize(s, context);
         return select_impl(context.str());
       }
@@ -312,7 +312,7 @@ namespace sqlpp
       template <typename Select>
       _prepared_statement_t prepare_select(Select& s)
       {
-        _context_t context(*this);
+        _context_t context{*this};
         serialize(s, context);
         return prepare_impl(context.str(), s._get_no_of_parameters(), s.get_no_of_result_columns());
       }
@@ -328,7 +328,7 @@ namespace sqlpp
       template <typename Insert>
       size_t insert(const Insert& i)
       {
-        _context_t context(*this);
+        _context_t context{*this};
         serialize(i, context);
         return insert_impl(context.str());
       }
@@ -336,7 +336,7 @@ namespace sqlpp
       template <typename Insert>
       _prepared_statement_t prepare_insert(Insert& i)
       {
-        _context_t context(*this);
+        _context_t context{*this};
         serialize(i, context);
         return prepare_impl(context.str(), i._get_no_of_parameters(), 0);
       }
@@ -352,7 +352,7 @@ namespace sqlpp
       template <typename Update>
       size_t update(const Update& u)
       {
-        _context_t context(*this);
+        _context_t context{*this};
         serialize(u, context);
         return update_impl(context.str());
       }
@@ -360,7 +360,7 @@ namespace sqlpp
       template <typename Update>
       _prepared_statement_t prepare_update(Update& u)
       {
-        _context_t context(*this);
+        _context_t context{*this};
         serialize(u, context);
         return prepare_impl(context.str(), u._get_no_of_parameters(), 0);
       }
@@ -376,7 +376,7 @@ namespace sqlpp
       template <typename Remove>
       size_t remove(const Remove& r)
       {
-        _context_t context(*this);
+        _context_t context{*this};
         serialize(r, context);
         return remove_impl(context.str());
       }
@@ -384,7 +384,7 @@ namespace sqlpp
       template <typename Remove>
       _prepared_statement_t prepare_remove(Remove& r)
       {
-        _context_t context(*this);
+        _context_t context{*this};
         serialize(r, context);
         return prepare_impl(context.str(), r._get_no_of_parameters(), 0);
       }
@@ -454,7 +454,7 @@ namespace sqlpp
       {
         if (_transaction_active)
         {
-          throw sqlpp::exception("MySQL: Cannot have more than one open transaction per connection");
+          throw sqlpp::exception{"MySQL: Cannot have more than one open transaction per connection"};
         }
         execute_statement(_handle, "START TRANSACTION");
         _transaction_active = true;
@@ -465,7 +465,7 @@ namespace sqlpp
       {
         if (not _transaction_active)
         {
-          throw sqlpp::exception("MySQL: Cannot commit a finished or failed transaction");
+          throw sqlpp::exception{"MySQL: Cannot commit a finished or failed transaction"};
         }
         _transaction_active = false;
         execute_statement(_handle, "COMMIT");
@@ -476,7 +476,7 @@ namespace sqlpp
       {
         if (not _transaction_active)
         {
-          throw sqlpp::exception("MySQL: Cannot rollback a finished or failed transaction");
+          throw sqlpp::exception{"MySQL: Cannot rollback a finished or failed transaction"};
         }
         if (report)
         {

--- a/include/sqlpp11/mysql/connection_config.h
+++ b/include/sqlpp11/mysql/connection_config.h
@@ -34,17 +34,17 @@ namespace sqlpp
   {
     struct connection_config
     {
-      std::string host = "localhost";
+      std::string host{"localhost"};
       std::string user;
       std::string password;
       std::string database;
-      unsigned int port = 0;
+      unsigned int port{0};
       std::string unix_socket;
-      unsigned long client_flag = 0;
-      std::string charset = "utf8";
-      bool auto_reconnect = true;
-      bool debug = false;
-      unsigned int connect_timeout_seconds = 0;  // 0 = do not override MySQL library default
+      unsigned long client_flag{0};
+      std::string charset{"utf8"};
+      bool auto_reconnect{true};
+      bool debug{false};
+      unsigned int connect_timeout_seconds{0};  // 0 = do not override MySQL library default
 
       bool operator==(const connection_config& other) const
       {

--- a/include/sqlpp11/mysql/detail/connection_handle.h
+++ b/include/sqlpp11/mysql/detail/connection_handle.h
@@ -43,7 +43,7 @@ namespace sqlpp
         if (config.connect_timeout_seconds != 0 &&
             mysql_options(mysql, MYSQL_OPT_CONNECT_TIMEOUT, &config.connect_timeout_seconds))
         {
-          throw sqlpp::exception("MySQL: could not set option MYSQL_OPT_CONNECT_TIMEOUT");
+          throw sqlpp::exception{"MySQL: could not set option MYSQL_OPT_CONNECT_TIMEOUT"};
         }
 
         if (!mysql_real_connect(mysql, config.host.empty() ? nullptr : config.host.c_str(),
@@ -51,17 +51,17 @@ namespace sqlpp
                                 config.password.empty() ? nullptr : config.password.c_str(), nullptr, config.port,
                                 config.unix_socket.empty() ? nullptr : config.unix_socket.c_str(), config.client_flag))
         {
-          throw sqlpp::exception("MySQL: could not connect to server: " + std::string(mysql_error(mysql)));
+          throw sqlpp::exception{"MySQL: could not connect to server: " + std::string{mysql_error(mysql)}};
         }
 
         if (mysql_set_character_set(mysql, config.charset.c_str()))
         {
-          throw sqlpp::exception("MySQL error: can't set character set " + config.charset);
+          throw sqlpp::exception{"MySQL error: can't set character set " + config.charset};
         }
 
         if (not config.database.empty() and mysql_select_db(mysql, config.database.c_str()))
         {
-          throw sqlpp::exception("MySQL error: can't select database '" + config.database + "'");
+          throw sqlpp::exception{"MySQL error: can't select database '" + config.database + "'"};
         }
       }
 
@@ -71,20 +71,20 @@ namespace sqlpp
         std::unique_ptr<MYSQL, void (*)(MYSQL*)> mysql;
 
         connection_handle(const std::shared_ptr<const connection_config>& conf) :
-          config(conf),
-          mysql(mysql_init(nullptr), mysql_close)
+          config{conf},
+          mysql{mysql_init(nullptr), mysql_close}
         {
           if (not mysql)
           {
-            throw sqlpp::exception("MySQL: could not init mysql data structure");
+            throw sqlpp::exception{"MySQL: could not init mysql data structure"};
           }
 
           if (config->auto_reconnect)
           {
-            my_bool my_true = true;
+            my_bool my_true{true};
             if (mysql_options(native_handle(), MYSQL_OPT_RECONNECT, &my_true))
             {
-              throw sqlpp::exception("MySQL: could not set option MYSQL_OPT_RECONNECT");
+              throw sqlpp::exception{"MySQL: could not set option MYSQL_OPT_RECONNECT"};
             }
           }
 

--- a/include/sqlpp11/mysql/detail/prepared_statement_handle.h
+++ b/include/sqlpp11/mysql/detail/prepared_statement_handle.h
@@ -54,10 +54,10 @@ namespace sqlpp
         {
           my_bool value;
 
-          wrapped_bool() : value(false)
+          wrapped_bool() : value{false}
           {
           }
-          wrapped_bool(bool v) : value(v)
+          wrapped_bool(bool v) : value{v}
           {
           }
           wrapped_bool(const wrapped_bool&) = default;
@@ -77,12 +77,12 @@ namespace sqlpp
 
         prepared_statement_handle_t(MYSQL_STMT* stmt, size_t no_of_parameters, size_t no_of_columns, bool debug_)
             : mysql_stmt(stmt),
-              stmt_params(no_of_parameters, MYSQL_BIND{}),
-              stmt_date_time_param_buffer(no_of_parameters, MYSQL_TIME{}),
-              stmt_param_is_null(no_of_parameters, false),
-              result_params(no_of_columns, MYSQL_BIND{}),
-              result_param_meta_data(no_of_columns, result_meta_data_t{}),
-              debug(debug_)
+              stmt_params(no_of_parameters, MYSQL_BIND{}),                  // ()-init for correct constructor
+              stmt_date_time_param_buffer(no_of_parameters, MYSQL_TIME{}),  // ()-init for correct constructor
+              stmt_param_is_null(no_of_parameters, false),                  // ()-init for correct constructor
+              result_params(no_of_columns, MYSQL_BIND{}),                   // ()-init for correct constructor
+              result_param_meta_data(no_of_columns, result_meta_data_t{}),  // ()-init for correct constructor
+              debug{debug_}
         {
         }
 

--- a/include/sqlpp11/mysql/detail/result_handle.h
+++ b/include/sqlpp11/mysql/detail/result_handle.h
@@ -37,7 +37,7 @@ namespace sqlpp
         MYSQL_RES* mysql_res;
         bool debug;
 
-        result_handle(MYSQL_RES* res, bool debug_) : mysql_res(res), debug(debug_)
+        result_handle(MYSQL_RES* res, bool debug_) : mysql_res{res}, debug{debug_}
         {
         }
 

--- a/include/sqlpp11/mysql/prepared_statement.h
+++ b/include/sqlpp11/mysql/prepared_statement.h
@@ -48,7 +48,7 @@ namespace sqlpp
 
     public:
       prepared_statement_t() = delete;
-      prepared_statement_t(std::shared_ptr<detail::prepared_statement_handle_t>&& handle) : _handle(std::move(handle))
+      prepared_statement_t(std::shared_ptr<detail::prepared_statement_handle_t>&& handle) : _handle{std::move(handle)}
       {
         if (_handle and _handle->debug)
           std::cerr << "MySQL debug: Constructing prepared_statement, using handle at " << _handle.get() << std::endl;
@@ -73,7 +73,7 @@ namespace sqlpp
           std::cerr << "MySQL debug: binding boolean parameter " << (*value ? "true" : "false")
                     << " at index: " << index << ", being " << (is_null ? "" : "not ") << "null" << std::endl;
         _handle->stmt_param_is_null[index] = is_null;
-        MYSQL_BIND& param = _handle->stmt_params[index];
+        MYSQL_BIND& param{_handle->stmt_params[index]};
         param.buffer_type = MYSQL_TYPE_TINY;
         param.buffer = const_cast<signed char*>(value);
         param.buffer_length = sizeof(*value);
@@ -89,7 +89,7 @@ namespace sqlpp
           std::cerr << "MySQL debug: binding integral parameter " << *value << " at index: " << index << ", being "
                     << (is_null ? "" : "not ") << "null" << std::endl;
         _handle->stmt_param_is_null[index] = is_null;
-        MYSQL_BIND& param = _handle->stmt_params[index];
+        MYSQL_BIND& param{_handle->stmt_params[index]};
         param.buffer_type = MYSQL_TYPE_LONGLONG;
         param.buffer = const_cast<int64_t*>(value);
         param.buffer_length = sizeof(*value);
@@ -105,7 +105,7 @@ namespace sqlpp
           std::cerr << "MySQL debug: binding unsigned integral parameter " << *value << " at index: " << index
                     << ", being " << (is_null ? "" : "not ") << "null" << std::endl;
         _handle->stmt_param_is_null[index] = is_null;
-        MYSQL_BIND& param = _handle->stmt_params[index];
+        MYSQL_BIND& param{_handle->stmt_params[index]};
         param.buffer_type = MYSQL_TYPE_LONGLONG;
         param.buffer = const_cast<uint64_t*>(value);
         param.buffer_length = sizeof(*value);
@@ -121,7 +121,7 @@ namespace sqlpp
           std::cerr << "MySQL debug: binding floating_point parameter " << *value << " at index: " << index
                     << ", being " << (is_null ? "" : "not ") << "null" << std::endl;
         _handle->stmt_param_is_null[index] = is_null;
-        MYSQL_BIND& param = _handle->stmt_params[index];
+        MYSQL_BIND& param{_handle->stmt_params[index]};
         param.buffer_type = MYSQL_TYPE_DOUBLE;
         param.buffer = const_cast<double*>(value);
         param.buffer_length = sizeof(*value);
@@ -137,7 +137,7 @@ namespace sqlpp
           std::cerr << "MySQL debug: binding text parameter " << *value << " at index: " << index << ", being "
                     << (is_null ? "" : "not ") << "null" << std::endl;
         _handle->stmt_param_is_null[index] = is_null;
-        MYSQL_BIND& param = _handle->stmt_params[index];
+        MYSQL_BIND& param{_handle->stmt_params[index]};
         param.buffer_type = MYSQL_TYPE_STRING;
         param.buffer = const_cast<char*>(value->data());
         param.buffer_length = value->size();
@@ -170,7 +170,7 @@ namespace sqlpp
         }
 
         _handle->stmt_param_is_null[index] = is_null;
-        MYSQL_BIND& param = _handle->stmt_params[index];
+        MYSQL_BIND& param{_handle->stmt_params[index]};
         param.buffer_type = MYSQL_TYPE_DATE;
         param.buffer = &bound_time;
         param.buffer_length = sizeof(MYSQL_TIME);
@@ -205,7 +205,7 @@ namespace sqlpp
         }
 
         _handle->stmt_param_is_null[index] = is_null;
-        MYSQL_BIND& param = _handle->stmt_params[index];
+        MYSQL_BIND& param{_handle->stmt_params[index]};
         param.buffer_type = MYSQL_TYPE_DATETIME;
         param.buffer = &bound_time;
         param.buffer_length = sizeof(MYSQL_TIME);


### PR DESCRIPTION
This is the second PR which cleans up the MySQL connector code. This one replaces old-style variable initializations with {}-initializations.
The only places where the old-style initialization has been kept is
- `auto var={value}` where C++11 uses an initializer_list.
- `std::vector(size_type count, ...)` which cannot be invoked via the {} syntax.

In the PostgreSQL connector we also have one case of
- `std::string(size_type count, ...)` which cannot be invoked via the {} syntax. However in the MySQL connector we don't have any uses of this constructor.

This PR was built and tested with
```
cmake -B build -DBUILD_POSTGRESQL_CONNECTOR=ON -DBUILD_SQLITE3_CONNECTOR=ON -DBUILD_MYSQL_CONNECTOR=ON -DBUILD_TESTING=ON -DUSE_SYSTEM_DATE=ON -DDEPENDENCY_CHECK=ON
```
All tests passed successfully.