### PR TITLE
Use brace-style initialization in the PostgreSQL connector

### DIFF
--- a/include/sqlpp11/postgresql/connection.h
+++ b/include/sqlpp11/postgresql/connection.h
@@ -138,7 +138,7 @@ namespace sqlpp
       void validate_connection_handle() const
       {
         if (!_handle) {
-          throw std::logic_error("connection handle used, but not initialized");
+          throw std::logic_error{"connection handle used, but not initialized"};
         }
       }
 
@@ -238,7 +238,7 @@ namespace sqlpp
       template <typename Select>
       bind_result_t select(const Select& s)
       {
-        _context_t ctx(*this);
+        _context_t ctx{*this};
         serialize(s, ctx);
         return select_impl(ctx.str());
       }
@@ -247,7 +247,7 @@ namespace sqlpp
       template <typename Select>
       _prepared_statement_t prepare_select(Select& s)
       {
-        _context_t ctx(*this);
+        _context_t ctx{*this};
         serialize(s, ctx);
         return prepare_impl(ctx.str(), ctx.count() - 1);
       }
@@ -263,7 +263,7 @@ namespace sqlpp
       template <typename Insert>
       size_t insert(const Insert& i)
       {
-        _context_t ctx(*this);
+        _context_t ctx{*this};
         serialize(i, ctx);
         return insert_impl(ctx.str());
       }
@@ -271,7 +271,7 @@ namespace sqlpp
       template <typename Insert>
       prepared_statement_t prepare_insert(Insert& i)
       {
-        _context_t ctx(*this);
+        _context_t ctx{*this};
         serialize(i, ctx);
         return prepare_impl(ctx.str(), ctx.count() - 1);
       }
@@ -287,7 +287,7 @@ namespace sqlpp
       template <typename Update>
       size_t update(const Update& u)
       {
-        _context_t ctx(*this);
+        _context_t ctx{*this};
         serialize(u, ctx);
         return update_impl(ctx.str());
       }
@@ -295,7 +295,7 @@ namespace sqlpp
       template <typename Update>
       prepared_statement_t prepare_update(Update& u)
       {
-        _context_t ctx(*this);
+        _context_t ctx{*this};
         serialize(u, ctx);
         return prepare_impl(ctx.str(), ctx.count() - 1);
       }
@@ -311,7 +311,7 @@ namespace sqlpp
       template <typename Remove>
       size_t remove(const Remove& r)
       {
-        _context_t ctx(*this);
+        _context_t ctx{*this};
         serialize(r, ctx);
         return remove_impl(ctx.str());
       }
@@ -319,7 +319,7 @@ namespace sqlpp
       template <typename Remove>
       prepared_statement_t prepare_remove(Remove& r)
       {
-        _context_t ctx(*this);
+        _context_t ctx{*this};
         serialize(r, ctx);
         return prepare_impl(ctx.str(), ctx.count() - 1);
       }
@@ -352,7 +352,7 @@ namespace sqlpp
           typename Enable = typename std::enable_if<not std::is_convertible<Execute, std::string>::value, void>::type>
       std::shared_ptr<detail::statement_handle_t> execute(const Execute& x)
       {
-        _context_t ctx(*this);
+        _context_t ctx{*this};
         serialize(x, ctx);
         return execute(ctx.str());
       }
@@ -360,7 +360,7 @@ namespace sqlpp
       template <typename Execute>
       _prepared_statement_t prepare_execute(Execute& x)
       {
-        _context_t ctx(*this);
+        _context_t ctx{*this};
         serialize(x, ctx);
         return prepare_impl(ctx.str(), ctx.count() - 1);
       }
@@ -440,7 +440,7 @@ namespace sqlpp
             level_str = "serializable";
             break;
           default:
-            throw sqlpp::exception("Invalid isolation level");
+            throw sqlpp::exception{"Invalid isolation level"};
         }
         std::string cmd = "SET default_transaction_isolation to '" + level_str + "'";
         execute(cmd);
@@ -453,7 +453,7 @@ namespace sqlpp
         auto status = res->result.status();
         if ((status != PGRES_TUPLES_OK) && (status != PGRES_COMMAND_OK))
         {
-          throw sqlpp::exception("PostgreSQL error: could not read default_transaction_isolation");
+          throw sqlpp::exception{"PostgreSQL error: could not read default_transaction_isolation"};
         }
 
         auto in = res->result.get_string_value(0, 0);
@@ -502,7 +502,7 @@ namespace sqlpp
       {
         if (_transaction_active)
         {
-          throw sqlpp::exception("PostgreSQL error: transaction already open");
+          throw sqlpp::exception{"PostgreSQL error: transaction already open"};
         }
         switch (level)
         {
@@ -540,7 +540,7 @@ namespace sqlpp
       {
         if (!_transaction_active)
         {
-          throw sqlpp::exception("PostgreSQL error: transaction failed or finished.");
+          throw sqlpp::exception{"PostgreSQL error: transaction failed or finished."};
         }
 
         _transaction_active = false;
@@ -552,7 +552,7 @@ namespace sqlpp
       {
         if (!_transaction_active)
         {
-          throw sqlpp::exception("PostgreSQL error: transaction failed or finished.");
+          throw sqlpp::exception{"PostgreSQL error: transaction failed or finished."};
         }
         execute("ROLLBACK");
         if (report)
@@ -578,7 +578,7 @@ namespace sqlpp
         {
           std::string err{PQresultErrorMessage(res)};
           PQclear(res);
-          throw sqlpp::postgresql::undefined_table(err, sql);
+          throw sqlpp::postgresql::undefined_table{err, sql};
         }
 
         // Parse the number and return.

--- a/include/sqlpp11/postgresql/detail/connection_handle.h
+++ b/include/sqlpp11/postgresql/detail/connection_handle.h
@@ -195,12 +195,12 @@ namespace sqlpp
         postgres.reset(PQconnectdb(conninfo.c_str()));
 
         if (!postgres)
-          throw std::bad_alloc();
+          throw std::bad_alloc{};
 
         if (check_connection() == false)
         {
-          std::string msg(PQerrorMessage(native_handle()));
-          throw broken_connection(std::move(msg));
+          std::string msg{PQerrorMessage(native_handle())};
+          throw broken_connection{std::move(msg)};
         }
       }
 

--- a/include/sqlpp11/postgresql/detail/prepared_statement_handle.h
+++ b/include/sqlpp11/postgresql/detail/prepared_statement_handle.h
@@ -106,8 +106,10 @@ namespace sqlpp
         std::vector<std::string> param_values;
 
         // ctor
-        prepared_statement_handle_t(connection_handle& _connection, const std::string& stmt, const size_t& param_count)
-          : statement_handle_t(_connection), null_values(param_count), param_values(param_count)
+        prepared_statement_handle_t(connection_handle& _connection, const std::string& stmt, const size_t& param_count) :
+          statement_handle_t{_connection},
+          null_values(param_count), // ()-init for correct constructor
+          param_values(param_count) // ()-init for correct constructor
         {
           generate_name();
           prepare(std::move(stmt));

--- a/include/sqlpp11/postgresql/exception.h
+++ b/include/sqlpp11/postgresql/exception.h
@@ -64,7 +64,7 @@ namespace sqlpp
       }
 
     public:
-      explicit failure(std::string whatarg) : sqlpp::exception(std::move(whatarg))
+      explicit failure(std::string whatarg) : sqlpp::exception{std::move(whatarg)}
       {
       }
     };
@@ -91,11 +91,11 @@ namespace sqlpp
     class DLL_PUBLIC broken_connection : public failure
     {
     public:
-      broken_connection() : failure("Connection to database failed")
+      broken_connection() : failure{"Connection to database failed"}
       {
       }
 
-      explicit broken_connection(std::string whatarg) : failure(std::move(whatarg))
+      explicit broken_connection(std::string whatarg) : failure{std::move(whatarg)}
       {
       }
     };
@@ -107,13 +107,13 @@ namespace sqlpp
       std::string m_Q;
 
     public:
-      sql_error() : failure("Failed query"), m_Q()
+      sql_error() : failure{"Failed query"}, m_Q{}
       {
       }
-      explicit sql_error(std::string whatarg) : failure(std::move(whatarg)), m_Q()
+      explicit sql_error(std::string whatarg) : failure{std::move(whatarg)}, m_Q{}
       {
       }
-      sql_error(std::string whatarg, std::string Q) : failure(std::move(whatarg)), m_Q(std::move(Q))
+      sql_error(std::string whatarg, std::string Q) : failure{std::move(whatarg)}, m_Q{std::move(Q)}
       {
       }
 
@@ -134,10 +134,10 @@ namespace sqlpp
       std::string m_Code;
 
     public:
-      sql_user_error(std::string whatarg, std::string code) : sql_error(std::move(whatarg)), m_Code(std::move(code))
+      sql_user_error(std::string whatarg, std::string code) : sql_error{std::move(whatarg)}, m_Code{std::move(code)}
       {
       }
-      sql_user_error(std::string whatarg, std::string query, std::string code) : sql_error(std::move(whatarg),std::move(query)), m_Code(std::move(code))
+      sql_user_error(std::string whatarg, std::string query, std::string code) : sql_error{std::move(whatarg),std::move(query)}, m_Code{std::move(code)}
       {
       }
 
@@ -159,7 +159,7 @@ namespace sqlpp
     class DLL_PUBLIC in_doubt_error : public failure
     {
     public:
-      explicit in_doubt_error(std::string whatarg) : failure(std::move(whatarg))
+      explicit in_doubt_error(std::string whatarg) : failure{std::move(whatarg)}
       {
       }
     };
@@ -168,10 +168,10 @@ namespace sqlpp
     class DLL_PUBLIC feature_not_supported : public sql_error
     {
     public:
-      explicit feature_not_supported(std::string err) : sql_error(std::move(err))
+      explicit feature_not_supported(std::string err) : sql_error{std::move(err)}
       {
       }
-      feature_not_supported(std::string err, std::string Q) : sql_error(std::move(err), std::move(Q))
+      feature_not_supported(std::string err, std::string Q) : sql_error{std::move(err), std::move(Q)}
       {
       }
     };
@@ -180,10 +180,10 @@ namespace sqlpp
     class DLL_PUBLIC data_exception : public sql_error
     {
     public:
-      explicit data_exception(std::string err) : sql_error(std::move(err))
+      explicit data_exception(std::string err) : sql_error{std::move(err)}
       {
       }
-      data_exception(std::string err, std::string Q) : sql_error(std::move(err), std::move(Q))
+      data_exception(std::string err, std::string Q) : sql_error{std::move(err), std::move(Q)}
       {
       }
     };
@@ -191,10 +191,10 @@ namespace sqlpp
     class DLL_PUBLIC integrity_constraint_violation : public sql_error
     {
     public:
-      explicit integrity_constraint_violation(std::string err) : sql_error(std::move(err))
+      explicit integrity_constraint_violation(std::string err) : sql_error{std::move(err)}
       {
       }
-      integrity_constraint_violation(std::string err, std::string Q) : sql_error(std::move(err), std::move(Q))
+      integrity_constraint_violation(std::string err, std::string Q) : sql_error{std::move(err), std::move(Q)}
       {
       }
     };
@@ -258,10 +258,10 @@ namespace sqlpp
     class DLL_PUBLIC invalid_cursor_state : public sql_error
     {
     public:
-      explicit invalid_cursor_state(std::string err) : sql_error(std::move(err))
+      explicit invalid_cursor_state(std::string err) : sql_error{std::move(err)}
       {
       }
-      invalid_cursor_state(std::string err, std::string Q) : sql_error(std::move(err), std::move(Q))
+      invalid_cursor_state(std::string err, std::string Q) : sql_error{std::move(err), std::move(Q)}
       {
       }
     };
@@ -269,10 +269,10 @@ namespace sqlpp
     class DLL_PUBLIC invalid_sql_statement_name : public sql_error
     {
     public:
-      explicit invalid_sql_statement_name(std::string err) : sql_error(std::move(err))
+      explicit invalid_sql_statement_name(std::string err) : sql_error{std::move(err)}
       {
       }
-      invalid_sql_statement_name(std::string err, std::string Q) : sql_error(std::move(err), std::move(Q))
+      invalid_sql_statement_name(std::string err, std::string Q) : sql_error{std::move(err), std::move(Q)}
       {
       }
     };
@@ -280,10 +280,10 @@ namespace sqlpp
     class DLL_PUBLIC invalid_cursor_name : public sql_error
     {
     public:
-      explicit invalid_cursor_name(std::string err) : sql_error(std::move(err))
+      explicit invalid_cursor_name(std::string err) : sql_error{std::move(err)}
       {
       }
-      invalid_cursor_name(std::string err, std::string Q) : sql_error(std::move(err), std::move(Q))
+      invalid_cursor_name(std::string err, std::string Q) : sql_error{std::move(err), std::move(Q)}
       {
       }
     };
@@ -294,10 +294,10 @@ namespace sqlpp
       /// Approximate position in string where error occurred, or -1 if unknown.
       const int error_position;
 
-      explicit syntax_error(std::string err, int pos = -1) : sql_error(std::move(err)), error_position(pos)
+      explicit syntax_error(std::string err, int pos = -1) : sql_error{std::move(err)}, error_position{pos}
       {
       }
-      syntax_error(std::string err, std::string Q, int pos = -1) : sql_error(std::move(err), std::move(Q)), error_position(pos)
+      syntax_error(std::string err, std::string Q, int pos = -1) : sql_error{std::move(err), std::move(Q)}, error_position{pos}
       {
       }
     };
@@ -305,10 +305,10 @@ namespace sqlpp
     class DLL_PUBLIC undefined_column : public syntax_error
     {
     public:
-      explicit undefined_column(std::string err) : syntax_error(std::move(err))
+      explicit undefined_column(std::string err) : syntax_error{std::move(err)}
       {
       }
-      undefined_column(std::string err, std::string Q) : syntax_error(std::move(err), std::move(Q))
+      undefined_column(std::string err, std::string Q) : syntax_error{std::move(err), std::move(Q)}
       {
       }
     };
@@ -316,10 +316,10 @@ namespace sqlpp
     class DLL_PUBLIC undefined_function : public syntax_error
     {
     public:
-      explicit undefined_function(std::string err) : syntax_error(std::move(err))
+      explicit undefined_function(std::string err) : syntax_error{std::move(err)}
       {
       }
-      undefined_function(std::string err, std::string Q) : syntax_error(std::move(err), std::move(Q))
+      undefined_function(std::string err, std::string Q) : syntax_error{std::move(err), std::move(Q)}
       {
       }
     };
@@ -327,10 +327,10 @@ namespace sqlpp
     class DLL_PUBLIC undefined_table : public syntax_error
     {
     public:
-      explicit undefined_table(std::string err) : syntax_error(std::move(err))
+      explicit undefined_table(std::string err) : syntax_error{std::move(err)}
       {
       }
-      undefined_table(std::string err, std::string Q) : syntax_error(std::move(err), std::move(Q))
+      undefined_table(std::string err, std::string Q) : syntax_error{std::move(err), std::move(Q)}
       {
       }
     };
@@ -338,10 +338,10 @@ namespace sqlpp
     class DLL_PUBLIC insufficient_privilege : public sql_error
     {
     public:
-      explicit insufficient_privilege(std::string err) : sql_error(std::move(err))
+      explicit insufficient_privilege(std::string err) : sql_error{std::move(err)}
       {
       }
-      insufficient_privilege(std::string err, std::string Q) : sql_error(std::move(err), std::move(Q))
+      insufficient_privilege(std::string err, std::string Q) : sql_error{std::move(err), std::move(Q)}
       {
       }
     };
@@ -350,10 +350,10 @@ namespace sqlpp
     class DLL_PUBLIC insufficient_resources : public sql_error
     {
     public:
-      explicit insufficient_resources(std::string err) : sql_error(std::move(err))
+      explicit insufficient_resources(std::string err) : sql_error{std::move(err)}
       {
       }
-      insufficient_resources(std::string err, std::string Q) : sql_error(std::move(err), std::move(Q))
+      insufficient_resources(std::string err, std::string Q) : sql_error{std::move(err), std::move(Q)}
       {
       }
     };
@@ -361,10 +361,10 @@ namespace sqlpp
     class DLL_PUBLIC disk_full : public insufficient_resources
     {
     public:
-      explicit disk_full(std::string err) : insufficient_resources(std::move(err))
+      explicit disk_full(std::string err) : insufficient_resources{std::move(err)}
       {
       }
-      disk_full(std::string err, std::string Q) : insufficient_resources(std::move(err), std::move(Q))
+      disk_full(std::string err, std::string Q) : insufficient_resources{std::move(err), std::move(Q)}
       {
       }
     };
@@ -372,10 +372,10 @@ namespace sqlpp
     class DLL_PUBLIC out_of_memory : public insufficient_resources
     {
     public:
-      explicit out_of_memory(std::string err) : insufficient_resources(std::move(err))
+      explicit out_of_memory(std::string err) : insufficient_resources{std::move(err)}
       {
       }
-      out_of_memory(std::string err, std::string Q) : insufficient_resources(std::move(err), std::move(Q))
+      out_of_memory(std::string err, std::string Q) : insufficient_resources{std::move(err), std::move(Q)}
       {
       }
     };
@@ -383,7 +383,7 @@ namespace sqlpp
     class DLL_PUBLIC too_many_connections : public broken_connection
     {
     public:
-      explicit too_many_connections(std::string err) : broken_connection(std::move(err))
+      explicit too_many_connections(std::string err) : broken_connection{std::move(err)}
       {
       }
     };
@@ -393,10 +393,10 @@ namespace sqlpp
     class DLL_PUBLIC plpgsql_error : public sql_error
     {
     public:
-      explicit plpgsql_error(std::string err) : sql_error(std::move(err))
+      explicit plpgsql_error(std::string err) : sql_error{std::move(err)}
       {
       }
-      plpgsql_error(std::string err, std::string Q) : sql_error(std::move(err), std::move(Q))
+      plpgsql_error(std::string err, std::string Q) : sql_error{std::move(err), std::move(Q)}
       {
       }
     };
@@ -405,10 +405,10 @@ namespace sqlpp
     class DLL_PUBLIC plpgsql_raise : public plpgsql_error
     {
     public:
-      explicit plpgsql_raise(std::string err) : plpgsql_error(std::move(err))
+      explicit plpgsql_raise(std::string err) : plpgsql_error{std::move(err)}
       {
       }
-      plpgsql_raise(std::string err, std::string Q) : plpgsql_error(std::move(err), std::move(Q))
+      plpgsql_raise(std::string err, std::string Q) : plpgsql_error{std::move(err), std::move(Q)}
       {
       }
     };
@@ -416,10 +416,10 @@ namespace sqlpp
     class DLL_PUBLIC plpgsql_no_data_found : public plpgsql_error
     {
     public:
-      explicit plpgsql_no_data_found(std::string err) : plpgsql_error(std::move(err))
+      explicit plpgsql_no_data_found(std::string err) : plpgsql_error{std::move(err)}
       {
       }
-      plpgsql_no_data_found(std::string err, std::string Q) : plpgsql_error(std::move(err), std::move(Q))
+      plpgsql_no_data_found(std::string err, std::string Q) : plpgsql_error{std::move(err), std::move(Q)}
       {
       }
     };
@@ -427,10 +427,10 @@ namespace sqlpp
     class DLL_PUBLIC plpgsql_too_many_rows : public plpgsql_error
     {
     public:
-      explicit plpgsql_too_many_rows(std::string err) : plpgsql_error(std::move(err))
+      explicit plpgsql_too_many_rows(std::string err) : plpgsql_error{std::move(err)}
       {
       }
-      plpgsql_too_many_rows(std::string err, std::string Q) : plpgsql_error(std::move(err), std::move(Q))
+      plpgsql_too_many_rows(std::string err, std::string Q) : plpgsql_error{std::move(err), std::move(Q)}
       {
       }
     };

--- a/include/sqlpp11/postgresql/prepared_statement.h
+++ b/include/sqlpp11/postgresql/prepared_statement.h
@@ -235,7 +235,7 @@ namespace sqlpp
         if (not is_null)
         {
           constexpr char hex_chars[16] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
-          auto param = std::string(value->size() * 2 + 2, '\0');
+          auto param = std::string(value->size() * 2 + 2, '\0');  // ()-init for correct constructor
           param[0] = '\\';
           param[1] = 'x';
           auto i = size_t{1};

--- a/include/sqlpp11/postgresql/result.h
+++ b/include/sqlpp11/postgresql/result.h
@@ -77,7 +77,7 @@ namespace sqlpp
       int affected_rows()
       {
         const char* const rows_str = PQcmdTuples(m_result);
-        return rows_str[0] ? std::stoi(std::string(rows_str)) : 0;
+        return rows_str[0] ? std::stoi(std::string{rows_str}) : 0;
       }
 
       int records_size() const
@@ -117,7 +117,7 @@ namespace sqlpp
       {
         check_index(record, field);
         auto t = int64_t{};
-        const auto txt = std::string(get_pq_value(m_result, record, field));
+        const auto txt = std::string{get_pq_value(m_result, record, field)};
         if(txt != "")
         {
           t = std::stoll(txt);
@@ -130,7 +130,7 @@ namespace sqlpp
       {
         check_index(record, field);
         auto t = uint64_t{};
-        const auto txt = std::string(get_pq_value(m_result, record, field));
+        const auto txt = std::string{get_pq_value(m_result, record, field)};
         if(txt != "")
         {
           t = std::stoull(txt);
@@ -143,7 +143,7 @@ namespace sqlpp
       {
         check_index(record, field);
         auto t = double{};
-        auto txt = std::string(get_pq_value(m_result, record, field));
+        auto txt = std::string{get_pq_value(m_result, record, field)};
         if(txt != "")
         {
           t = std::stod(txt);
@@ -207,39 +207,39 @@ namespace sqlpp
               switch (code[1])
               {
                 case '8':
-                  throw broken_connection(err);
+                  throw broken_connection{err};
                 case 'A':
-                  throw feature_not_supported(err, query);
+                  throw feature_not_supported{err, query};
               }
               break;
             case '2':
               switch (code[1])
               {
                 case '2':
-                  throw data_exception(err, query);
+                  throw data_exception{err, query};
                 case '3':
                   if (strcmp(code, "23001") == 0)
-                    throw restrict_violation(err, query);
+                    throw restrict_violation{err, query};
                   if (strcmp(code, "23502") == 0)
-                    throw not_null_violation(err, query);
+                    throw not_null_violation{err, query};
                   if (strcmp(code, "23503") == 0)
-                    throw foreign_key_violation(err, query);
+                    throw foreign_key_violation{err, query};
                   if (strcmp(code, "23505") == 0)
-                    throw unique_violation(err, query);
+                    throw unique_violation{err, query};
                   if (strcmp(code, "23514") == 0)
-                    throw check_violation(err, query);
-                  throw integrity_constraint_violation(err, query);
+                    throw check_violation{err, query};
+                  throw integrity_constraint_violation{err, query};
                 case '4':
-                  throw invalid_cursor_state(err, query);
+                  throw invalid_cursor_state{err, query};
                 case '6':
-                  throw invalid_sql_statement_name(err, query);
+                  throw invalid_sql_statement_name{err, query};
               }
               break;
             case '3':
               switch (code[1])
               {
                 case '4':
-                  throw invalid_cursor_name(err, query);
+                  throw invalid_cursor_name{err, query};
               }
               break;
             case '4':
@@ -247,15 +247,15 @@ namespace sqlpp
               {
                 case '2':
                   if (strcmp(code, "42501") == 0)
-                    throw insufficient_privilege(err, query);
+                    throw insufficient_privilege{err, query};
                   if (strcmp(code, "42601") == 0)
-                    throw syntax_error(err, query, error_position());
+                    throw syntax_error{err, query, error_position()};
                   if (strcmp(code, "42703") == 0)
-                    throw undefined_column(err, query);
+                    throw undefined_column{err, query};
                   if (strcmp(code, "42883") == 0)
-                    throw undefined_function(err, query);
+                    throw undefined_function{err, query};
                   if (strcmp(code, "42P01") == 0)
-                    throw undefined_table(err, query);
+                    throw undefined_table{err, query};
               }
               break;
             case '5':
@@ -263,34 +263,34 @@ namespace sqlpp
               {
                 case '3':
                   if (strcmp(code, "53100") == 0)
-                    throw disk_full(err, query);
+                    throw disk_full{err, query};
                   if (strcmp(code, "53200") == 0)
-                    throw out_of_memory(err, query);
+                    throw out_of_memory{err, query};
                   if (strcmp(code, "53300") == 0)
-                    throw too_many_connections(err);
-                  throw insufficient_resources(err, query);
+                    throw too_many_connections{err};
+                  throw insufficient_resources{err, query};
               }
               break;
 
             case 'P':
               if (strcmp(code, "P0001") == 0)
-                throw plpgsql_raise(err, query);
+                throw plpgsql_raise{err, query};
               if (strcmp(code, "P0002") == 0)
-                throw plpgsql_no_data_found(err, query);
+                throw plpgsql_no_data_found{err, query};
               if (strcmp(code, "P0003") == 0)
-                throw plpgsql_too_many_rows(err, query);
-              throw plpgsql_error(err, query);
+                throw plpgsql_too_many_rows{err, query};
+              throw plpgsql_error{err, query};
               break;
             default:
-              throw sql_user_error(err, query, code);
+              throw sql_user_error{err, query, code};
           }
-        throw sql_error(err, query);
+        throw sql_error{err, query};
       }
 
       std::string status_error() const
       {
         if (!m_result)
-          throw failure("No result set given");
+          throw failure{"No result set given"};
 
         std::string err;
 
@@ -319,8 +319,8 @@ namespace sqlpp
           case PGRES_PIPELINE_ABORTED:
   #endif
           default:
-            throw sqlpp::exception("pqxx::result: Unrecognized response code " +
-                                  std::to_string(PQresultStatus(m_result)));
+            throw sqlpp::exception{"pqxx::result: Unrecognized response code " +
+                                  std::to_string(PQresultStatus(m_result))};
         }
         return err;
       }
@@ -332,7 +332,7 @@ namespace sqlpp
         {
           const char* p = PQresultErrorField(m_result, PG_DIAG_STATEMENT_POSITION);
           if (p)
-            pos = std::stoi(std::string(p));
+            pos = std::stoi(std::string{p});
         }
         return pos;
       }
@@ -340,7 +340,7 @@ namespace sqlpp
       void check_index(int record, int field) const noexcept(false)
       {
         if (record > records_size() || field > field_count())
-          throw std::out_of_range("PostgreSQL error: index out of range");
+          throw std::out_of_range{"PostgreSQL error: index out of range"};
       }
 
       // move PQgetvalue to implementation so we don't depend on the libpq in the

--- a/include/sqlpp11/postgresql/result_field.h
+++ b/include/sqlpp11/postgresql/result_field.h
@@ -75,7 +75,7 @@ namespace sqlpp
         case 'F':
           return c + 10 - 'A';
       }
-      throw sqlpp::exception(std::string("Unexpected hex char: ") + static_cast<char>(c));
+      throw sqlpp::exception{std::string{"Unexpected hex char: "} + static_cast<char>(c)};
     }
 
     inline void hex_assign(std::vector<unsigned char>& value, const uint8_t* blob, size_t len)


### PR DESCRIPTION
This PR updates the PostgreSQL connector code by replacing the old-style variable initializations with uniform (brace) initializations. There are several places where the parentheses-style initialization has been kept:
* auto var=value;
* std::vector(size_type count, ...) which cannot be invoked via the {} syntax.
* std::string(size_t n, char c) which cannot be invoked via the {} syntax.

This PR was built and tested with

cmake -B build -DBUILD_POSTGRESQL_CONNECTOR=ON -DBUILD_SQLITE3_CONNECTOR=ON -DBUILD_MYSQL_CONNECTOR=ON -DBUILD_TESTING=ON -DUSE_SYSTEM_DATE=ON -DDEPENDENCY_CHECK=ON

All tests passed successfully.