### PR TITLE
MySQL: const std::string -> const std::string&

### DIFF
--- a/include/sqlpp11/mysql/connection.h
+++ b/include/sqlpp11/mysql/connection.h
@@ -487,7 +487,7 @@ namespace sqlpp
       }
 
       //! report a rollback failure (will be called by transactions in case of a rollback failure in the destructor)
-      void report_rollback_failure(const std::string message) noexcept
+      void report_rollback_failure(const std::string& message) noexcept
       {
         std::cerr << "MySQL message:" << message << std::endl;
       }


### PR DESCRIPTION
Minor cleanup of the MySQL connector. 
Change a parameter type from `const std::string` to `const std::string&`