### PR TITLE
Replace ()-init with {}-init in the SQLite3 connector

### DIFF
--- a/include/sqlpp11/sqlite3/bind_result.h
+++ b/include/sqlpp11/sqlite3/bind_result.h
@@ -104,7 +104,7 @@ namespace sqlpp
 
     public:
       bind_result_t() = default;
-      bind_result_t(const std::shared_ptr<detail::prepared_statement_handle_t>& handle) : _handle(handle)
+      bind_result_t(const std::shared_ptr<detail::prepared_statement_handle_t>& handle) : _handle{handle}
       {
         if (_handle and _handle->debug)
           std::cerr << "Sqlite3 debug: Constructing bind result, using handle at " << _handle.get() << std::endl;
@@ -230,7 +230,7 @@ namespace sqlpp
         if (detail::check_date_digits(date_string))
         {
           const auto ymd = ::date::year(std::atoi(date_string)) / atoi(date_string + 5) / atoi(date_string + 8);
-          *value = ::sqlpp::chrono::day_point(ymd);
+          *value = ::sqlpp::chrono::day_point{ymd};
         }
         else
         {
@@ -261,7 +261,7 @@ namespace sqlpp
         {
           const auto ymd =
               ::date::year(std::atoi(date_time_string)) / atoi(date_time_string + 5) / atoi(date_time_string + 8);
-          *value = ::sqlpp::chrono::day_point(ymd);
+          *value = ::sqlpp::chrono::day_point{ymd};
         }
         else
         {
@@ -275,8 +275,8 @@ namespace sqlpp
         const auto time_string = date_time_string + 11; // YYYY-MM-DDT
         if (detail::check_time_digits(time_string))
         {
-          *value += ::std::chrono::hours(std::atoi(time_string + 0)) +
-                    std::chrono::minutes(std::atoi(time_string + 3)) + std::chrono::seconds(std::atoi(time_string + 6));
+          *value += ::std::chrono::hours{std::atoi(time_string + 0)} +
+                    std::chrono::minutes{std::atoi(time_string + 3)} + std::chrono::seconds{std::atoi(time_string + 6)};
         }
         else
         {
@@ -285,7 +285,7 @@ namespace sqlpp
         const auto ms_string = time_string + 9; // hh:mm:ss.
         if (detail::check_ms_digits(ms_string) and ms_string[4] == '\0')
         {
-          *value += ::std::chrono::milliseconds(std::atoi(ms_string));
+          *value += ::std::chrono::milliseconds{std::atoi(ms_string)};
         }
         else
         {
@@ -308,7 +308,7 @@ namespace sqlpp
           case SQLITE_DONE:
             return false;
           default:
-            throw sqlpp::exception("Sqlite3 error: Unexpected return value for sqlite3_step()");
+            throw sqlpp::exception{"Sqlite3 error: Unexpected return value for sqlite3_step()"};
         }
       }
     };

--- a/include/sqlpp11/sqlite3/connection.h
+++ b/include/sqlpp11/sqlite3/connection.h
@@ -72,16 +72,16 @@ namespace sqlpp
         if (handle->config->debug)
           std::cerr << "Sqlite3 debug: Preparing: '" << statement << "'" << std::endl;
 
-        detail::prepared_statement_handle_t result(nullptr, handle->config->debug);
+        detail::prepared_statement_handle_t result{nullptr, handle->config->debug};
 
         auto rc = sqlite3_prepare_v2(handle->native_handle(), statement.c_str(), static_cast<int>(statement.size()),
                                      &result.sqlite_statement, nullptr);
 
         if (rc != SQLITE_OK)
         {
-          throw sqlpp::exception(
+          throw sqlpp::exception{
               "Sqlite3 error: Could not prepare statement: " + std::string(sqlite3_errmsg(handle->native_handle())) +
-              " (statement was >>" + (rc == SQLITE_TOOBIG ? statement.substr(0, 128) + "..." : statement) + "<<\n");
+              " (statement was >>" + (rc == SQLITE_TOOBIG ? statement.substr(0, 128) + "..." : statement) + "<<\n"};
         }
 
         return result;
@@ -99,8 +99,8 @@ namespace sqlpp
           default:
             if (handle->config->debug)
               std::cerr << "Sqlite3 debug: sqlite3_step return code: " << rc << std::endl;
-            throw sqlpp::exception("Sqlite3 error: Could not execute statement: " +
-                                   std::string(sqlite3_errmsg(handle->native_handle())));
+            throw sqlpp::exception{"Sqlite3 error: Could not execute statement: " +
+                                   std::string(sqlite3_errmsg(handle->native_handle()))};
         }
       }
     }  // namespace detail
@@ -110,7 +110,7 @@ namespace sqlpp
 
     struct context_t
     {
-      context_t(const connection_base& db) : _db(db), _count(1)
+      context_t(const connection_base& db) : _db{db}, _count{1}
       {
       }
 
@@ -153,16 +153,16 @@ namespace sqlpp
         active
       };
 
-      transaction_status_type _transaction_status = transaction_status_type::none;
+      transaction_status_type _transaction_status{transaction_status_type::none};
 
       // direct execution
       bind_result_t select_impl(const std::string& statement)
       {
-        std::unique_ptr<detail::prepared_statement_handle_t> prepared(
-            new detail::prepared_statement_handle_t(prepare_statement(_handle, statement)));
+        std::unique_ptr<detail::prepared_statement_handle_t> prepared{
+            new detail::prepared_statement_handle_t(prepare_statement(_handle, statement))};
         if (!prepared)
         {
-          throw sqlpp::exception("Sqlite3 error: Could not store result set");
+          throw sqlpp::exception{"Sqlite3 error: Could not store result set"};
         }
 
         return {std::move(prepared)};
@@ -193,8 +193,8 @@ namespace sqlpp
       // prepared execution
       prepared_statement_t prepare_impl(const std::string& statement)
       {
-        return {std::unique_ptr<detail::prepared_statement_handle_t>(
-            new detail::prepared_statement_handle_t(prepare_statement(_handle, statement)))};
+        return {std::unique_ptr<detail::prepared_statement_handle_t>{
+            new detail::prepared_statement_handle_t(prepare_statement(_handle, statement))}};
       }
 
       bind_result_t run_prepared_select_impl(prepared_statement_t& prepared_statement)
@@ -263,7 +263,7 @@ namespace sqlpp
       template <typename Select>
       bind_result_t select(const Select& s)
       {
-        _context_t context(*this);
+        _context_t context{*this};
         serialize(s, context);
         return select_impl(context.str());
       }
@@ -271,7 +271,7 @@ namespace sqlpp
       template <typename Select>
       _prepared_statement_t prepare_select(Select& s)
       {
-        _context_t context(*this);
+        _context_t context{*this};
         serialize(s, context);
         return prepare_impl(context.str());
       }
@@ -288,7 +288,7 @@ namespace sqlpp
       template <typename Insert>
       size_t insert(const Insert& i)
       {
-        _context_t context(*this);
+        _context_t context{*this};
         serialize(i, context);
         return insert_impl(context.str());
       }
@@ -296,7 +296,7 @@ namespace sqlpp
       template <typename Insert>
       _prepared_statement_t prepare_insert(Insert& i)
       {
-        _context_t context(*this);
+        _context_t context{*this};
         serialize(i, context);
         return prepare_impl(context.str());
       }
@@ -313,7 +313,7 @@ namespace sqlpp
       template <typename Update>
       size_t update(const Update& u)
       {
-        _context_t context(*this);
+        _context_t context{*this};
         serialize(u, context);
         return update_impl(context.str());
       }
@@ -321,7 +321,7 @@ namespace sqlpp
       template <typename Update>
       _prepared_statement_t prepare_update(Update& u)
       {
-        _context_t context(*this);
+        _context_t context{*this};
         serialize(u, context);
         return prepare_impl(context.str());
       }
@@ -338,7 +338,7 @@ namespace sqlpp
       template <typename Remove>
       size_t remove(const Remove& r)
       {
-        _context_t context(*this);
+        _context_t context{*this};
         serialize(r, context);
         return remove_impl(context.str());
       }
@@ -346,7 +346,7 @@ namespace sqlpp
       template <typename Remove>
       _prepared_statement_t prepare_remove(Remove& r)
       {
-        _context_t context(*this);
+        _context_t context{*this};
         serialize(r, context);
         return prepare_impl(context.str());
       }
@@ -372,7 +372,7 @@ namespace sqlpp
           typename Enable = typename std::enable_if<not std::is_convertible<Execute, std::string>::value, void>::type>
       size_t execute(const Execute& x)
       {
-        _context_t context(*this);
+        _context_t context{*this};
         serialize(x, context);
         return execute(context.str());
       }
@@ -380,7 +380,7 @@ namespace sqlpp
       template <typename Execute>
       _prepared_statement_t prepare_execute(Execute& x)
       {
-        _context_t context(*this);
+        _context_t context{*this};
         serialize(x, context);
         return prepare_impl(context.str());
       }
@@ -472,7 +472,7 @@ namespace sqlpp
       {
         if (_transaction_status == transaction_status_type::active)
         {
-          throw sqlpp::exception("Sqlite3 error: Cannot have more than one open transaction per connection");
+          throw sqlpp::exception{"Sqlite3 error: Cannot have more than one open transaction per connection"};
         }
 
         _transaction_status = transaction_status_type::maybe;
@@ -486,7 +486,7 @@ namespace sqlpp
       {
         if (_transaction_status == transaction_status_type::none)
         {
-          throw sqlpp::exception("Sqlite3 error: Cannot commit a finished or failed transaction");
+          throw sqlpp::exception{"Sqlite3 error: Cannot commit a finished or failed transaction"};
         }
         _transaction_status = transaction_status_type::maybe;
         auto prepared = prepare_statement(_handle, "COMMIT");
@@ -500,7 +500,7 @@ namespace sqlpp
       {
         if (_transaction_status == transaction_status_type::none)
         {
-          throw sqlpp::exception("Sqlite3 error: Cannot rollback a finished or failed transaction");
+          throw sqlpp::exception{"Sqlite3 error: Cannot rollback a finished or failed transaction"};
         }
         if (report)
         {

--- a/include/sqlpp11/sqlite3/connection_config.h
+++ b/include/sqlpp11/sqlite3/connection_config.h
@@ -35,7 +35,7 @@ namespace sqlpp
   {
     struct connection_config
     {
-      connection_config() : path_to_database(), flags(0), vfs(), debug(false),password("")
+      connection_config() : path_to_database{}, flags{0}, vfs{}, debug{false},password{}
       {
       }
       connection_config(const connection_config&) = default;
@@ -44,7 +44,7 @@ namespace sqlpp
       connection_config& operator=(connection_config&&) = default;
 
       connection_config(std::string path, int fl = 0, std::string vf = "", bool dbg = false,std::string password="")
-          : path_to_database(std::move(path)), flags(fl), vfs(std::move(vf)), debug(dbg),password(password)
+          : path_to_database{std::move(path)}, flags{fl}, vfs{std::move(vf)}, debug{dbg},password{password}
       {
       }
 

--- a/include/sqlpp11/sqlite3/detail/connection_handle.h
+++ b/include/sqlpp11/sqlite3/detail/connection_handle.h
@@ -53,8 +53,8 @@ namespace sqlpp
         std::unique_ptr<::sqlite3, int (*)(::sqlite3*)> sqlite;
 
         connection_handle(const std::shared_ptr<const connection_config>& conf) :
-          config(conf),
-          sqlite(nullptr, sqlite3_close)
+          config{conf},
+          sqlite{nullptr, sqlite3_close}
         {
 #ifdef SQLPP_DYNAMIC_LOADING
           init_sqlite("");
@@ -67,7 +67,7 @@ namespace sqlpp
           {
             const std::string msg = sqlite3_errmsg(sqlite_ptr);
             sqlite3_close(sqlite_ptr);
-            throw sqlpp::exception("Sqlite3 error: Can't open database: " + msg);
+            throw sqlpp::exception{"Sqlite3 error: Can't open database: " + msg};
           }
 
           sqlite.reset(sqlite_ptr);
@@ -80,7 +80,7 @@ namespace sqlpp
             {
               const std::string msg = sqlite3_errmsg(native_handle());
               sqlite3_close(native_handle());
-              throw sqlpp::exception("Sqlite3 error: Can't set password to database: " + msg);
+              throw sqlpp::exception{"Sqlite3 error: Can't set password to database: " + msg};
             }
           }
 #endif

--- a/include/sqlpp11/sqlite3/detail/prepared_statement_handle.h
+++ b/include/sqlpp11/sqlite3/detail/prepared_statement_handle.h
@@ -48,14 +48,14 @@ namespace sqlpp
         sqlite3_stmt* sqlite_statement;
         bool debug;
 
-        prepared_statement_handle_t(sqlite3_stmt* statement, bool debug_) : sqlite_statement(statement), debug(debug_)
+        prepared_statement_handle_t(sqlite3_stmt* statement, bool debug_) : sqlite_statement{statement}, debug{debug_}
         {
         }
 
         prepared_statement_handle_t(const prepared_statement_handle_t&) = delete;
         prepared_statement_handle_t(prepared_statement_handle_t&& rhs) :
-          sqlite_statement(rhs.sqlite_statement),
-          debug(rhs.debug)
+          sqlite_statement{rhs.sqlite_statement},
+          debug{rhs.debug}
         {
           rhs.sqlite_statement = nullptr;
         }

--- a/include/sqlpp11/sqlite3/prepared_statement.h
+++ b/include/sqlpp11/sqlite3/prepared_statement.h
@@ -60,14 +60,14 @@ namespace sqlpp
           case SQLITE_OK:
             return;
           case SQLITE_RANGE:
-            throw sqlpp::exception("Sqlite3 error: " + std::string(type) + " bind value out of range");
+            throw sqlpp::exception{"Sqlite3 error: " + std::string(type) + " bind value out of range"};
           case SQLITE_NOMEM:
-            throw sqlpp::exception("Sqlite3 error: " + std::string(type) + " bind out of memory");
+            throw sqlpp::exception{"Sqlite3 error: " + std::string(type) + " bind out of memory"};
           case SQLITE_TOOBIG:
-            throw sqlpp::exception("Sqlite3 error: " + std::string(type) + " bind too big");
+            throw sqlpp::exception{"Sqlite3 error: " + std::string(type) + " bind too big"};
           default:
-            throw sqlpp::exception("Sqlite3 error: " + std::string(type) +
-                                   " bind returned unexpected value: " + std::to_string(result));
+            throw sqlpp::exception{"Sqlite3 error: " + std::string(type) +
+                                   " bind returned unexpected value: " + std::to_string(result)};
         }
       }
     }  // namespace detail


### PR DESCRIPTION
This PR replaces the ()-initalization with {}-initialization (uniform initialization) in the SQLite3 connector code.

The library with this PR was built and tested with
```
cmake -B build -DBUILD_POSTGRESQL_CONNECTOR=ON -DBUILD_SQLITE3_CONNECTOR=ON -DBUILD_MYSQL_CONNECTOR=ON -DBUILD_TESTING=ON -DUSE_SYSTEM_DATE=ON -DDEPENDENCY_CHECK=ON
cmake --build build -- VERBOSE=1
cd build
ctest
```
All tests passed successfully.