### PR TITLE
A couple of minor cleanups in the PostgreSQL connector

### DIFF
--- a/include/sqlpp11/postgresql/detail/connection_handle.h
+++ b/include/sqlpp11/postgresql/detail/connection_handle.h
@@ -58,179 +58,174 @@ namespace sqlpp
         std::unique_ptr<PGconn, void(*)(PGconn*)>  postgres;
         std::set<std::string> prepared_statement_names;
 
-        connection_handle(const std::shared_ptr<const connection_config>& config);
+        connection_handle(const std::shared_ptr<const connection_config>& conf)
+            : config{conf}, postgres{nullptr, PQfinish}
+        {
+#ifdef SQLPP_DYNAMIC_LOADING
+          init_pg("");
+#endif
+          if (config->debug)
+          {
+            std::cerr << "PostgreSQL debug: connecting to the database server." << std::endl;
+          }
+
+          // Open connection
+          std::string conninfo = "";
+          if (!config->host.empty())
+          {
+            conninfo.append("host=" + config->host);
+          }
+          if (!config->hostaddr.empty())
+          {
+            conninfo.append(" hostaddr=" + config->hostaddr);
+          }
+          if (config->port != 5432)
+          {
+            conninfo.append(" port=" + std::to_string(config->port));
+          }
+          if (!config->dbname.empty())
+          {
+            conninfo.append(" dbname=" + config->dbname);
+          }
+          if (!config->user.empty())
+          {
+            conninfo.append(" user=" + config->user);
+          }
+          if (!config->password.empty())
+          {
+            conninfo.append(" password=" + config->password);
+          }
+          if (config->connect_timeout != 0)
+          {
+            conninfo.append(" connect_timeout=" + std::to_string(config->connect_timeout));
+          }
+          if (!config->client_encoding.empty())
+          {
+            conninfo.append(" client_encoding=" + config->client_encoding);
+          }
+          if (!config->options.empty())
+          {
+            conninfo.append(" options=" + config->options);
+          }
+          if (!config->application_name.empty())
+          {
+            conninfo.append(" application_name=" + config->application_name);
+          }
+          if (!config->fallback_application_name.empty())
+          {
+            conninfo.append(" fallback_application_name=" + config->fallback_application_name);
+          }
+          if (!config->keepalives)
+          {
+            conninfo.append(" keepalives=0");
+          }
+          if (config->keepalives_idle != 0)
+          {
+            conninfo.append(" keepalives_idle=" + std::to_string(config->keepalives_idle));
+          }
+          if (config->keepalives_interval != 0)
+          {
+            conninfo.append(" keepalives_interval=" + std::to_string(config->keepalives_interval));
+          }
+          if (config->keepalives_count != 0)
+          {
+            conninfo.append(" keepalives_count=" + std::to_string(config->keepalives_count));
+          }
+          switch (config->sslmode)
+          {
+            case connection_config::sslmode_t::disable:
+              conninfo.append(" sslmode=disable");
+              break;
+            case connection_config::sslmode_t::allow:
+              conninfo.append(" sslmode=allow");
+              break;
+            case connection_config::sslmode_t::require:
+              conninfo.append(" sslmode=require");
+              break;
+            case connection_config::sslmode_t::verify_ca:
+              conninfo.append(" sslmode=verify-ca");
+              break;
+            case connection_config::sslmode_t::verify_full:
+              conninfo.append(" sslmode=verify-full");
+              break;
+            case connection_config::sslmode_t::prefer:
+              break;
+          }
+          if (!config->sslcompression)
+          {
+            conninfo.append(" sslcompression=0");
+          }
+          if (!config->sslcert.empty())
+          {
+            conninfo.append(" sslcert=" + config->sslcert);
+          }
+          if (!config->sslkey.empty())
+          {
+            conninfo.append(" sslkey=" + config->sslkey);
+          }
+          if (!config->sslrootcert.empty())
+          {
+            conninfo.append(" sslrootcert=" + config->sslrootcert);
+          }
+          if (!config->requirepeer.empty())
+          {
+            conninfo.append(" requirepeer=" + config->requirepeer);
+          }
+          if (!config->krbsrvname.empty())
+          {
+            conninfo.append(" krbsrvname=" + config->krbsrvname);
+          }
+          if (!config->service.empty())
+          {
+            conninfo.append(" service=" + config->service);
+          }
+
+          postgres.reset(PQconnectdb(conninfo.c_str()));
+
+          if (!postgres)
+            throw std::bad_alloc{};
+
+          if (check_connection() == false)
+          {
+            std::string msg{PQerrorMessage(native_handle())};
+            throw broken_connection{std::move(msg)};
+          }
+        }
+
         connection_handle(const connection_handle&) = delete;
         connection_handle(connection_handle&&) = default;
-        ~connection_handle();
+
+        ~connection_handle()
+        {
+          // Debug
+          if (config->debug)
+          {
+            std::cerr << "PostgreSQL debug: closing database connection." << std::endl;
+          }
+        }
+
         connection_handle& operator=(const connection_handle&) = delete;
         connection_handle& operator=(connection_handle&&) = default;
 
-        void deallocate_prepared_statement(const std::string& name);
-        PGconn* native_handle() const;
-        bool check_connection() const;
+        void deallocate_prepared_statement(const std::string& name)
+        {
+          std::string cmd = "DEALLOCATE \"" + name + "\"";
+          PGresult* result = PQexec(native_handle(), cmd.c_str());
+          PQclear(result);
+          prepared_statement_names.erase(name);
+        }
+
+        PGconn* native_handle() const
+        {
+          return postgres.get();
+        }
+
+        bool check_connection() const
+        {
+          auto nh = native_handle();
+          return nh && (PQstatus(nh) == CONNECTION_OK);
+        }
       };
-
-      inline connection_handle::connection_handle(const std::shared_ptr<const connection_config>& conf)
-          : config{conf}, postgres{nullptr, PQfinish}
-      {
-#ifdef SQLPP_DYNAMIC_LOADING
-        init_pg("");
-#endif
-        if (config->debug)
-        {
-          std::cerr << "PostgreSQL debug: connecting to the database server." << std::endl;
-        }
-
-        // Open connection
-        std::string conninfo = "";
-        if (!config->host.empty())
-        {
-          conninfo.append("host=" + config->host);
-        }
-        if (!config->hostaddr.empty())
-        {
-          conninfo.append(" hostaddr=" + config->hostaddr);
-        }
-        if (config->port != 5432)
-        {
-          conninfo.append(" port=" + std::to_string(config->port));
-        }
-        if (!config->dbname.empty())
-        {
-          conninfo.append(" dbname=" + config->dbname);
-        }
-        if (!config->user.empty())
-        {
-          conninfo.append(" user=" + config->user);
-        }
-        if (!config->password.empty())
-        {
-          conninfo.append(" password=" + config->password);
-        }
-        if (config->connect_timeout != 0)
-        {
-          conninfo.append(" connect_timeout=" + std::to_string(config->connect_timeout));
-        }
-        if (!config->client_encoding.empty())
-        {
-          conninfo.append(" client_encoding=" + config->client_encoding);
-        }
-        if (!config->options.empty())
-        {
-          conninfo.append(" options=" + config->options);
-        }
-        if (!config->application_name.empty())
-        {
-          conninfo.append(" application_name=" + config->application_name);
-        }
-        if (!config->fallback_application_name.empty())
-        {
-          conninfo.append(" fallback_application_name=" + config->fallback_application_name);
-        }
-        if (!config->keepalives)
-        {
-          conninfo.append(" keepalives=0");
-        }
-        if (config->keepalives_idle != 0)
-        {
-          conninfo.append(" keepalives_idle=" + std::to_string(config->keepalives_idle));
-        }
-        if (config->keepalives_interval != 0)
-        {
-          conninfo.append(" keepalives_interval=" + std::to_string(config->keepalives_interval));
-        }
-        if (config->keepalives_count != 0)
-        {
-          conninfo.append(" keepalives_count=" + std::to_string(config->keepalives_count));
-        }
-        switch (config->sslmode)
-        {
-          case connection_config::sslmode_t::disable:
-            conninfo.append(" sslmode=disable");
-            break;
-          case connection_config::sslmode_t::allow:
-            conninfo.append(" sslmode=allow");
-            break;
-          case connection_config::sslmode_t::require:
-            conninfo.append(" sslmode=require");
-            break;
-          case connection_config::sslmode_t::verify_ca:
-            conninfo.append(" sslmode=verify-ca");
-            break;
-          case connection_config::sslmode_t::verify_full:
-            conninfo.append(" sslmode=verify-full");
-            break;
-          case connection_config::sslmode_t::prefer:
-            break;
-        }
-        if (!config->sslcompression)
-        {
-          conninfo.append(" sslcompression=0");
-        }
-        if (!config->sslcert.empty())
-        {
-          conninfo.append(" sslcert=" + config->sslcert);
-        }
-        if (!config->sslkey.empty())
-        {
-          conninfo.append(" sslkey=" + config->sslkey);
-        }
-        if (!config->sslrootcert.empty())
-        {
-          conninfo.append(" sslrootcert=" + config->sslrootcert);
-        }
-        if (!config->requirepeer.empty())
-        {
-          conninfo.append(" requirepeer=" + config->requirepeer);
-        }
-        if (!config->krbsrvname.empty())
-        {
-          conninfo.append(" krbsrvname=" + config->krbsrvname);
-        }
-        if (!config->service.empty())
-        {
-          conninfo.append(" service=" + config->service);
-        }
-
-        postgres.reset(PQconnectdb(conninfo.c_str()));
-
-        if (!postgres)
-          throw std::bad_alloc{};
-
-        if (check_connection() == false)
-        {
-          std::string msg{PQerrorMessage(native_handle())};
-          throw broken_connection{std::move(msg)};
-        }
-      }
-
-      inline connection_handle::~connection_handle()
-      {
-        // Debug
-        if (config->debug)
-        {
-          std::cerr << "PostgreSQL debug: closing database connection." << std::endl;
-        }
-      }
-
-      inline void connection_handle::deallocate_prepared_statement(const std::string& name)
-      {
-         std::string cmd = "DEALLOCATE \"" + name + "\"";
-         PGresult* result = PQexec(native_handle(), cmd.c_str());
-         PQclear(result);
-         prepared_statement_names.erase(name);
-      }
-
-      inline PGconn* connection_handle::native_handle() const
-      {
-        return postgres.get();
-      }
-
-      inline bool connection_handle::check_connection() const
-      {
-        auto nh = native_handle();
-        return nh && (PQstatus(nh) == CONNECTION_OK);
-      }
     }
   }
 }

--- a/include/sqlpp11/postgresql/detail/connection_handle.h
+++ b/include/sqlpp11/postgresql/detail/connection_handle.h
@@ -71,7 +71,7 @@ namespace sqlpp
       };
 
       inline connection_handle::connection_handle(const std::shared_ptr<const connection_config>& conf)
-          : config(conf), postgres{nullptr, PQfinish}
+          : config{conf}, postgres{nullptr, PQfinish}
       {
 #ifdef SQLPP_DYNAMIC_LOADING
         init_pg("");


### PR DESCRIPTION
This PR performs a couple of minor cleanups in the PostgreSQL connector, which I missed in the previous PRs:

- Replace ()-init with {}-init in the member initializer list of `sqlpp::postgresql::detail::connection_handle `
- Move the method definitions for `sqlpp::postgresql::detail::connection_handle` inside the class