### PR TITLE
Fix a bug in the MySQL date/time test

### DIFF
--- a/tests/mysql/usage/DateTime.cpp
+++ b/tests/mysql/usage/DateTime.cpp
@@ -92,14 +92,14 @@ int DateTime(int, char*[])
       require_equal(__LINE__, row.colDayPoint.value(), ::sqlpp::chrono::day_point{});
       require_equal(__LINE__, row.colTimePoint.is_null(), true);
       require_equal(__LINE__, row.colTimePoint.value(), ::sqlpp::chrono::microsecond_point{});
-      require_close(__LINE__, row.colDateTimePoint.value(), std::chrono::system_clock::now());
+      require_close(__LINE__, row.colDateTimePoint.value(), sqlpp::chrono::floor<std::chrono::seconds>(std::chrono::system_clock::now()));
     }
 
     auto statement = db.prepare(select(tab.colDateTimePoint).from(tab).unconditionally());
     for (const auto& row : db(statement))
     {
       require_equal(__LINE__, row.colDateTimePoint.is_null(), false);
-      require_close(__LINE__, row.colDateTimePoint.value(), std::chrono::system_clock::now());
+      require_close(__LINE__, row.colDateTimePoint.value(), sqlpp::chrono::floor<std::chrono::seconds>(std::chrono::system_clock::now()));
     }
 
     db(update(tab).set(tab.colDayPoint = today, tab.colTimePoint = now).unconditionally());


### PR DESCRIPTION
There is an obscure bug in the MySQL date/time test (`sqlpp11.mysql.usage.DateTime`) which causes the test to fail even though the MySQL connector works correctly. Then the relevant error message in `LastTest.log` says something like:
```
95: abs(TIMESTAMP '2023-08-21 23:43:32.000000' - TIMESTAMP '2023-08-21 23:43:33.018933656') > 1s
```
In fact the real time difference is less than 1s, e.g. 0.25s, but the test fails due to incorrect comparison of two values, where the first one (`2023-08-21 23:43:32.000000`) has been rounded down.

The bug is caused by the fact that the corresponding database column (`col_date_time_point`) is of type `datetime` which automatically rounds the saved timestamp down to the nearest second and the compared value is taken from
`std::chrono::system_clock::now()` without any rounding. So for example if the value is saved in the database at `2023-08-21 23:43:32.999999`, then it will be rounded down to `2023-08-21 23:43:32.000000`. After that at `2023-08-21 23:43:33.018933656` the time difference will be calculated incorrectly as
`1.018933656`, while in fact it is just `0.018933657`.

The fix which is used in the PR is to round down the second timestamp too.

The bug manifests rarely. On `Intel(R) Core(TM) i5-2400 CPU @ 3.10GHz` each time when the test `sqlpp11.mysql.usage.DateTime` is run there is a chance of about 0.5% to 1% for the bug to show up. The slower the CPU is the higher the chance for the bug to show up.

The easiest way to reproduce the bug is to run:
```
ctest -R sqlpp11.mysql.usage.DateTime --repeat-until-fail 1000
```

On a side note - the new timestamp-parsing code (which uses regexes) is slower than the old code so the bug has higher chance of showing up - with the old code usually it takes less than 200 test iterations for the bug to show up and with the new code in most cases 100 iterations are sufficient. I am preparing a new PR to speed up the time-parsing code. But the current test bugfix is not directly related to that issue, so I decided to use two separate PRs for the current bugfix and for the speed-up of the date/time parser.