### PR TITLE
Move method definitions inside corresponding classes

### DIFF
--- a/include/sqlpp11/connection.h
+++ b/include/sqlpp11/connection.h
@@ -46,8 +46,17 @@ namespace sqlpp
 
     // Constructors
     normal_connection() = default;
-    normal_connection(const _config_t& config);
-    normal_connection(const _config_ptr_t& config);
+
+    normal_connection(const _config_t& config) :
+      normal_connection{std::make_shared<_config_t>(config)}
+    {
+    }
+
+    normal_connection(const _config_ptr_t& config) :
+      ConnectionBase{std::make_unique<_handle_t>(config)}
+    {
+    }
+
     normal_connection(const normal_connection&) = delete;
     normal_connection(normal_connection&&) = default;
 
@@ -56,29 +65,14 @@ namespace sqlpp
     normal_connection& operator=(normal_connection&&) = default;
 
     // creates a connection handle and connects to database
-    void connectUsing(const _config_ptr_t& config) noexcept(false);
+    void connectUsing(const _config_ptr_t& config) noexcept(false)
+    {
+      ConnectionBase::_handle = std::make_unique<_handle_t>(config);
+    }
 
   private:
     using _handle_t = typename ConnectionBase::_handle_t;
   };
-
-  template<typename ConnectionBase>
-  normal_connection<ConnectionBase>::normal_connection(const _config_t& config) :
-    normal_connection{std::make_shared<_config_t>(config)}
-  {
-  }
-
-  template<typename ConnectionBase>
-  normal_connection<ConnectionBase>::normal_connection(const _config_ptr_t& config) :
-    ConnectionBase{std::make_unique<_handle_t>(config)}
-  {
-  }
-
-  template<typename ConnectionBase>
-  void normal_connection<ConnectionBase>::connectUsing(const _config_ptr_t& config) noexcept(false)
-  {
-    ConnectionBase::_handle = std::make_unique<_handle_t>(config);
-  }
 
   // Forward declaration
   template<typename ConnectionBase>

--- a/include/sqlpp11/connection.h
+++ b/include/sqlpp11/connection.h
@@ -37,7 +37,7 @@ namespace sqlpp
   };
 
   // Normal (non-pooled) connection
-  template<typename ConnectionBase>
+  template <typename ConnectionBase>
   class normal_connection : public ConnectionBase
   {
   public:
@@ -47,13 +47,11 @@ namespace sqlpp
     // Constructors
     normal_connection() = default;
 
-    normal_connection(const _config_t& config) :
-      normal_connection{std::make_shared<_config_t>(config)}
+    normal_connection(const _config_t& config) : normal_connection{std::make_shared<_config_t>(config)}
     {
     }
 
-    normal_connection(const _config_ptr_t& config) :
-      ConnectionBase{std::make_unique<_handle_t>(config)}
+    normal_connection(const _config_ptr_t& config) : ConnectionBase{std::make_unique<_handle_t>(config)}
     {
     }
 
@@ -75,11 +73,11 @@ namespace sqlpp
   };
 
   // Forward declaration
-  template<typename ConnectionBase>
+  template <typename ConnectionBase>
   class connection_pool;
 
   // Pooled connection
-  template<typename ConnectionBase>
+  template <typename ConnectionBase>
   class pooled_connection : public ConnectionBase
   {
     friend class connection_pool<ConnectionBase>::pool_core;
@@ -117,15 +115,13 @@ namespace sqlpp
     _pool_core_ptr_t _pool_core;
 
     // Constructors used by the connection pool
-    pooled_connection(_handle_ptr_t&& handle, _pool_core_ptr_t pool_core) :
-      ConnectionBase{std::move(handle)},
-      _pool_core{pool_core}
+    pooled_connection(_handle_ptr_t&& handle, _pool_core_ptr_t pool_core)
+        : ConnectionBase{std::move(handle)}, _pool_core{pool_core}
     {
     }
 
-    pooled_connection(const _config_ptr_t& config, _pool_core_ptr_t pool_core) :
-      ConnectionBase{std::make_unique<_handle_t>(config)},
-      _pool_core{pool_core}
+    pooled_connection(const _config_ptr_t& config, _pool_core_ptr_t pool_core)
+        : ConnectionBase{std::make_unique<_handle_t>(config)}, _pool_core{pool_core}
     {
     }
 

--- a/include/sqlpp11/connection_pool.h
+++ b/include/sqlpp11/connection_pool.h
@@ -99,46 +99,39 @@ namespace sqlpp
     };
 
     connection_pool() = default;
-    connection_pool(const _config_ptr_t& connection_config, std::size_t capacity);
+
+    connection_pool(const _config_ptr_t& connection_config, std::size_t capacity) :
+      _core{std::make_shared<pool_core>(connection_config, capacity)}
+    {
+    }
+
     connection_pool(const connection_pool&) = delete;
     connection_pool(connection_pool&&) = default;
 
     connection_pool& operator=(const connection_pool&) = delete;
     connection_pool& operator=(connection_pool&&) = default;
 
-    void initialize(const _config_ptr_t& connection_config, std::size_t capacity);
-    _pooled_connection_t get();
+    void initialize(const _config_ptr_t& connection_config, std::size_t capacity)
+    {
+      if (_core)
+      {
+        throw std::runtime_error{"Connection pool already initialized"};
+      }
+      _core = std::make_shared<pool_core>(connection_config, capacity);
+    }
+
+    _pooled_connection_t get()
+    {
+      return _core->get();
+    }
+
     // Returns number of connections available in the pool. Only used in tests.
-    std::size_t available();
+    std::size_t available()
+    {
+      return _core->available();
+    }
 
   private:
     std::shared_ptr<pool_core> _core;
   };
-
-  template<typename ConnectionBase>
-  connection_pool<ConnectionBase>::connection_pool(const _config_ptr_t& connection_config, std::size_t capacity) :
-    _core{std::make_shared<pool_core>(connection_config, capacity)}
-  {
-  }
-
-  template<typename ConnectionBase>
-  void connection_pool<ConnectionBase>::initialize(const _config_ptr_t& connection_config, std::size_t capacity)
-  {
-    if (_core) {
-      throw std::runtime_error{"Connection pool already initialized"};
-    }
-    _core = std::make_shared<pool_core>(connection_config, capacity);
-  }
-
-  template<typename ConnectionBase>
-  typename connection_pool<ConnectionBase>::_pooled_connection_t connection_pool<ConnectionBase>::get()
-  {
-    return _core->get();
-  }
-
-  template<typename ConnectionBase>
-  std::size_t connection_pool<ConnectionBase>::available()
-  {
-    return _core->available();
-  }
 } // namespace sqlpp

--- a/include/sqlpp11/connection_pool.h
+++ b/include/sqlpp11/connection_pool.h
@@ -33,7 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace sqlpp
 {
-  template<typename ConnectionBase>
+  template <typename ConnectionBase>
   class connection_pool
   {
   public:
@@ -44,15 +44,14 @@ namespace sqlpp
     class pool_core : public std::enable_shared_from_this<pool_core>
     {
     public:
-      pool_core(const _config_ptr_t& connection_config, std::size_t capacity) :
-        _connection_config{connection_config},
-        _handles{capacity}
+      pool_core(const _config_ptr_t& connection_config, std::size_t capacity)
+          : _connection_config{connection_config}, _handles{capacity}
       {
       }
 
       pool_core() = delete;
-      pool_core(const pool_core &) = delete;
-      pool_core(pool_core &&) = delete;
+      pool_core(const pool_core&) = delete;
+      pool_core(pool_core&&) = delete;
 
       pool_core& operator=(const pool_core&) = delete;
       pool_core& operator=(pool_core&&) = delete;
@@ -69,18 +68,16 @@ namespace sqlpp
         _handles.pop_front();
         lock.unlock();
         // If the fetched connection is dead, drop it and create a new one on the fly
-        return
-          handle->check_connection() ?
-          _pooled_connection_t{std::move(handle), this->shared_from_this()} :
-          _pooled_connection_t{_connection_config, this->shared_from_this()};
+        return handle->check_connection() ? _pooled_connection_t{std::move(handle), this->shared_from_this()}
+                                          : _pooled_connection_t{_connection_config, this->shared_from_this()};
       }
 
       void put(_handle_ptr_t& handle)
       {
         std::unique_lock<std::mutex> lock{_mutex};
-        if (_handles.full ())
+        if (_handles.full())
         {
-                _handles.set_capacity (_handles.capacity () + 5);
+          _handles.set_capacity(_handles.capacity() + 5);
         }
         _handles.push_back(std::move(handle));
       }
@@ -100,8 +97,8 @@ namespace sqlpp
 
     connection_pool() = default;
 
-    connection_pool(const _config_ptr_t& connection_config, std::size_t capacity) :
-      _core{std::make_shared<pool_core>(connection_config, capacity)}
+    connection_pool(const _config_ptr_t& connection_config, std::size_t capacity)
+        : _core{std::make_shared<pool_core>(connection_config, capacity)}
     {
     }
 
@@ -134,4 +131,4 @@ namespace sqlpp
   private:
     std::shared_ptr<pool_core> _core;
   };
-} // namespace sqlpp
+}  // namespace sqlpp

--- a/include/sqlpp11/connection_pool.h
+++ b/include/sqlpp11/connection_pool.h
@@ -44,7 +44,12 @@ namespace sqlpp
     class pool_core : public std::enable_shared_from_this<pool_core>
     {
     public:
-      pool_core(const _config_ptr_t& connection_config, std::size_t capacity);
+      pool_core(const _config_ptr_t& connection_config, std::size_t capacity) :
+        _connection_config{connection_config},
+        _handles{capacity}
+      {
+      }
+
       pool_core() = delete;
       pool_core(const pool_core &) = delete;
       pool_core(pool_core &&) = delete;
@@ -52,10 +57,40 @@ namespace sqlpp
       pool_core& operator=(const pool_core&) = delete;
       pool_core& operator=(pool_core&&) = delete;
 
-      _pooled_connection_t get();
-      void put(_handle_ptr_t& handle);
+      _pooled_connection_t get()
+      {
+        std::unique_lock<std::mutex> lock{_mutex};
+        if (_handles.empty())
+        {
+          lock.unlock();
+          return _pooled_connection_t{_connection_config, this->shared_from_this()};
+        }
+        auto handle = std::move(_handles.front());
+        _handles.pop_front();
+        lock.unlock();
+        // If the fetched connection is dead, drop it and create a new one on the fly
+        return
+          handle->check_connection() ?
+          _pooled_connection_t{std::move(handle), this->shared_from_this()} :
+          _pooled_connection_t{_connection_config, this->shared_from_this()};
+      }
+
+      void put(_handle_ptr_t& handle)
+      {
+        std::unique_lock<std::mutex> lock{_mutex};
+        if (_handles.full ())
+        {
+                _handles.set_capacity (_handles.capacity () + 5);
+        }
+        _handles.push_back(std::move(handle));
+      }
+
       // Returns number of connections available in the pool. Only used in tests.
-      std::size_t available();
+      std::size_t available()
+      {
+        std::unique_lock<std::mutex> lock{_mutex};
+        return _handles.size();
+      }
 
     private:
       _config_ptr_t _connection_config;
@@ -79,48 +114,6 @@ namespace sqlpp
   private:
     std::shared_ptr<pool_core> _core;
   };
-
-  template<typename ConnectionBase>
-  connection_pool<ConnectionBase>::pool_core::pool_core(const _config_ptr_t& connection_config, std::size_t capacity) :
-    _connection_config{connection_config},
-    _handles{capacity}
-  {
-  }
-
-  template<typename ConnectionBase>
-  typename connection_pool<ConnectionBase>::_pooled_connection_t connection_pool<ConnectionBase>::pool_core::get()
-  {
-    std::unique_lock<std::mutex> lock{_mutex};
-    if (_handles.empty()) {
-      lock.unlock();
-      return _pooled_connection_t{_connection_config, this->shared_from_this()};
-    }
-    auto handle = std::move(_handles.front());
-    _handles.pop_front();
-    lock.unlock();
-    // If the fetched connection is dead, drop it and create a new one on the fly
-    return
-      handle->check_connection() ?
-      _pooled_connection_t{std::move(handle), this->shared_from_this()} :
-      _pooled_connection_t{_connection_config, this->shared_from_this()};
-  }
-
-  template<typename ConnectionBase>
-  void connection_pool<ConnectionBase>::pool_core::put(_handle_ptr_t& handle)
-  {
-    std::unique_lock<std::mutex> lock{_mutex};
-    if (_handles.full ()) {
-            _handles.set_capacity (_handles.capacity () + 5);
-    }
-    _handles.push_back(std::move(handle));
-  }
-
-  template<typename ConnectionBase>
-  std::size_t connection_pool<ConnectionBase>::pool_core::available()
-  {
-    std::unique_lock<std::mutex> lock{_mutex};
-    return _handles.size();
-  }
 
   template<typename ConnectionBase>
   connection_pool<ConnectionBase>::connection_pool(const _config_ptr_t& connection_config, std::size_t capacity) :


### PR DESCRIPTION
This PR makes a few minor cleanups of the connection pool code. 

The method definitions of
```
sqlpp::connection_pool
sqlpp::connection_pool::pool_core
sqlpp::pooled_connection
sqlpp::normal_connection
```
are moved inside their corresponding classes. Also when I originally wrote the code in these methods, I used K&R indentation and the rest of the project seems to use Allman indentation so now I changed the indentation of the above classes to Allman-style.

Essentially I changed the code from
```
if (cond) {
    ...
} else {
    ...
}
```

to
```
if (cond)
{
    ...
}
else
{
    ...
}
```

As usual the PR was built and tested with 
```
cmake -B build -DBUILD_POSTGRESQL_CONNECTOR=ON -DBUILD_SQLITE3_CONNECTOR=ON -DBUILD_MYSQL_CONNECTOR=ON -DBUILD_TESTING=ON -DUSE_SYSTEM_DATE=ON -DDEPENDENCY_CHECK=ON
cmake --build build
cd build
ctest
```
All tests passes successfully.