### PR TITLE
Replace std::make_unique<T>(..) with std::unique_ptr{new T{...}}

### DIFF
--- a/include/sqlpp11/connection.h
+++ b/include/sqlpp11/connection.h
@@ -51,7 +51,7 @@ namespace sqlpp
     {
     }
 
-    normal_connection(const _config_ptr_t& config) : ConnectionBase{std::make_unique<_handle_t>(config)}
+    normal_connection(const _config_ptr_t& config) : ConnectionBase{std::unique_ptr<_handle_t>{new _handle_t{config}}}
     {
     }
 
@@ -65,7 +65,7 @@ namespace sqlpp
     // creates a connection handle and connects to database
     void connectUsing(const _config_ptr_t& config) noexcept(false)
     {
-      ConnectionBase::_handle = std::make_unique<_handle_t>(config);
+      ConnectionBase::_handle = std::unique_ptr<_handle_t>{new _handle_t{config}};
     }
 
   private:
@@ -121,7 +121,7 @@ namespace sqlpp
     }
 
     pooled_connection(const _config_ptr_t& config, _pool_core_ptr_t pool_core)
-        : ConnectionBase{std::make_unique<_handle_t>(config)}, _pool_core{pool_core}
+        : ConnectionBase{std::unique_ptr<_handle_t>{new _handle_t{config}}}, _pool_core{pool_core}
     {
     }
 

--- a/tests/include/ConnectionPoolTests.h
+++ b/tests/include/ConnectionPoolTests.h
@@ -236,7 +236,7 @@ namespace sqlpp
       void test_destruction_order(typename Pool::_config_ptr_t config)
       {
         // Create a pool, get a connection from it and then destroy the pool before the connection
-        auto pool = std::make_unique<Pool>(config, 5);
+        auto pool = std::unique_ptr<Pool>{new Pool{config, 5}};
         auto conn = pool->get();
         pool = nullptr;
       }


### PR DESCRIPTION
This PR replaces std::make_unique<T>(..) with std::unique_ptr{new T{...}}
This change fixes https://github.com/rbock/sqlpp11/issues/523
