### PR TITLE
Fix handling of -DSQLPP11_TESTS_CXX_STD=...

### DIFF
--- a/tests/core/serialize/CMakeLists.txt
+++ b/tests/core/serialize/CMakeLists.txt
@@ -58,9 +58,9 @@ target_link_libraries(sqlpp11_core_serialize PRIVATE sqlpp11::sqlpp11 sqlpp11_te
 
 # conditionally bump to a higher C++ standard to test compatibility
 if (SQLPP11_TESTS_CXX_STD)
-    set_property(TARGET sqlpp11_test_serializer PROPERTY CXX_STANDARD ${SQLPP11_TESTS_CXX_STD})
-    set_property(TARGET sqlpp11_test_serializer PROPERTY CXX_STANDARD_REQUIRED yes)
-    set_property(TARGET sqlpp11_test_serializer PROPERTY CXX_EXTENSIONS no)
+    set_property(TARGET sqlpp11_core_serialize PROPERTY CXX_STANDARD ${SQLPP11_TESTS_CXX_STD})
+    set_property(TARGET sqlpp11_core_serialize PROPERTY CXX_STANDARD_REQUIRED yes)
+    set_property(TARGET sqlpp11_core_serialize PROPERTY CXX_EXTENSIONS no)
 endif()
 
 foreach(test_file IN LISTS test_files)


### PR DESCRIPTION
This PR fixes a CMake error when passing `-DSQLPP11_TESTS_CXX_STD=11`  (or any other C++ version) to the build script.

This is what happens with the current build script:
```
root@localhost:/usr/local/projects/github/sqlpp11# cmake -B build -DBUILD_TESTING=ON -DUSE_SYSTEM_DATE=ON -DDEPENDENCY_CHECK=ON -DSQLPP11_TESTS_CXX_STD=C++11
-- The CXX compiler identification is GNU 13.2.1
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Found Boost: /usr/lib64/cmake/Boost-1.78.0/BoostConfig.cmake (found suitable version "1.78.0", minimum required is "1.50")  
CMake Error at tests/core/serialize/CMakeLists.txt:61 (set_property):
  set_property could not find TARGET sqlpp11_test_serializer.  Perhaps it has
  not yet been created.


CMake Error at tests/core/serialize/CMakeLists.txt:62 (set_property):
  set_property could not find TARGET sqlpp11_test_serializer.  Perhaps it has
  not yet been created.


CMake Error at tests/core/serialize/CMakeLists.txt:63 (set_property):
  set_property could not find TARGET sqlpp11_test_serializer.  Perhaps it has
  not yet been created.


-- Found Python3: /usr/bin/python3.11 (found version "3.11.4") found components: Interpreter 
-- Pyparsing is installed: Enabling ddl2cpp tests.
-- Configuring incomplete, errors occurred!
```