### PR TITLE
Add connection methods is_connected() and ping_server()

### DIFF
--- a/connector_api/connection.h
+++ b/connector_api/connection.h
@@ -67,8 +67,11 @@ namespace sqlpp
       connection_handle& operator=(connection_handle&&);
 
       // Used by the connection pool to check if the connection handle is still
-      // connected to the database server
-      bool check_connection();
+      // connected to the database server.
+      bool is_connected();
+
+      // Send a dummy request to the server to check if the connection is still alive
+      bool ping_server();
 
       // Optional method that returns a native (low-level) database handle.
       // Used by the test code to test the connection pool

--- a/include/sqlpp11/connection.h
+++ b/include/sqlpp11/connection.h
@@ -29,8 +29,8 @@
 
 #include <sqlpp11/compat/make_unique.h>
 
-#include <functional>
 #include <memory>
+#include <utility>
 
 namespace sqlpp
 {

--- a/include/sqlpp11/connection.h
+++ b/include/sqlpp11/connection.h
@@ -38,9 +38,27 @@ namespace sqlpp
   {
   };
 
+  template <typename ConnectionBase>
+  class common_connection : public ConnectionBase
+  {
+  public:
+    bool is_connected() const
+    {
+      return ConnectionBase::_handle ? ConnectionBase::_handle->is_connected() : false;
+    }
+
+    bool ping_server() const
+    {
+      return ConnectionBase::_handle ? ConnectionBase::_handle->ping_server() : false;
+    }
+
+  protected:
+    using ConnectionBase::ConnectionBase;
+  };
+
   // Normal (non-pooled) connection
   template <typename ConnectionBase>
-  class normal_connection : public ConnectionBase
+  class normal_connection : public common_connection<ConnectionBase>
   {
   public:
     using _config_t = typename ConnectionBase::_config_t;
@@ -53,7 +71,8 @@ namespace sqlpp
     {
     }
 
-    normal_connection(const _config_ptr_t& config) : ConnectionBase{compat::make_unique<_handle_t>(config)}
+    normal_connection(const _config_ptr_t& config)
+        : common_connection<ConnectionBase>{compat::make_unique<_handle_t>(config)}
     {
     }
 
@@ -80,7 +99,7 @@ namespace sqlpp
 
   // Pooled connection
   template <typename ConnectionBase>
-  class pooled_connection : public ConnectionBase
+  class pooled_connection : public common_connection<ConnectionBase>
   {
     friend class connection_pool<ConnectionBase>::pool_core;
 
@@ -118,12 +137,12 @@ namespace sqlpp
 
     // Constructors used by the connection pool
     pooled_connection(_handle_ptr_t&& handle, _pool_core_ptr_t pool_core)
-        : ConnectionBase{std::move(handle)}, _pool_core{pool_core}
+        : common_connection<ConnectionBase>{std::move(handle)}, _pool_core{pool_core}
     {
     }
 
     pooled_connection(const _config_ptr_t& config, _pool_core_ptr_t pool_core)
-        : ConnectionBase{compat::make_unique<_handle_t>(config)}, _pool_core{pool_core}
+        : common_connection<ConnectionBase>{compat::make_unique<_handle_t>(config)}, _pool_core{pool_core}
     {
     }
 

--- a/include/sqlpp11/connection_pool.h
+++ b/include/sqlpp11/connection_pool.h
@@ -68,8 +68,8 @@ namespace sqlpp
         _handles.pop_front();
         lock.unlock();
         // If the fetched connection is dead, drop it and create a new one on the fly
-        return handle->check_connection() ? _pooled_connection_t{std::move(handle), this->shared_from_this()}
-                                          : _pooled_connection_t{_connection_config, this->shared_from_this()};
+        return handle->is_connected() ? _pooled_connection_t{std::move(handle), this->shared_from_this()}
+                                      : _pooled_connection_t{_connection_config, this->shared_from_this()};
       }
 
       void put(_handle_ptr_t& handle)

--- a/include/sqlpp11/mysql/connection.h
+++ b/include/sqlpp11/mysql/connection.h
@@ -281,7 +281,7 @@ namespace sqlpp
         return serialize(t, context);
       }
 
-      bool is_valid() const
+      [[deprecated("Use ping_server() instead")]] bool is_valid() const
       {
         return _handle->ping_server();
       }

--- a/include/sqlpp11/mysql/connection.h
+++ b/include/sqlpp11/mysql/connection.h
@@ -283,7 +283,7 @@ namespace sqlpp
 
       bool is_valid() const
       {
-        return _handle->check_connection();
+        return _handle->ping_server();
       }
 
       void reconnect()

--- a/include/sqlpp11/mysql/detail/connection_handle.h
+++ b/include/sqlpp11/mysql/detail/connection_handle.h
@@ -101,10 +101,17 @@ namespace sqlpp
           return mysql.get();
         }
 
-        bool check_connection() const
+        bool is_connected() const
         {
-          auto nh = native_handle();
-          return nh && (mysql_ping(nh) == 0);
+          // The connection is established in the constructor and the MySQL client
+          // library doesn't seem to have a way to check passively if the connection
+          // is still valid
+          return true;
+        }
+
+        bool ping_server() const
+        {
+          return mysql_ping(native_handle()) == 0;
         }
 
         void reconnect()

--- a/include/sqlpp11/sqlite3/detail/connection_handle.h
+++ b/include/sqlpp11/sqlite3/detail/connection_handle.h
@@ -96,9 +96,22 @@ namespace sqlpp
           return sqlite.get();
         }
 
-        bool check_connection() const
+        bool is_connected() const
         {
-          return native_handle() != nullptr;
+          // The connection is established in the constructor and the SQLite3 client
+          // library doesn't seem to have a way to check passively if the connection
+          // is still valid
+          return true;
+        }
+
+        bool ping_server() const
+        {
+          // Loosely based on the implementation of PHP's pg_ping()
+          if (sqlite3_exec(native_handle(), "SELECT 1", nullptr, nullptr, nullptr) != SQLITE_OK)
+          {
+            return false;
+          }
+          return true;
         }
       };
     }  // namespace detail

--- a/tests/include/ConnectionTests.h
+++ b/tests/include/ConnectionTests.h
@@ -1,0 +1,69 @@
+#pragma once
+
+/*
+Copyright (c) 2023, Vesselin Atanasov
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this
+   list of conditions and the following disclaimer in the documentation and/or
+   other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stdexcept>
+
+namespace sqlpp
+{
+  namespace test
+  {
+    namespace
+    {
+      template <typename Connection>
+      void test_conn_empty()
+      {
+        Connection db;
+        if (db.is_connected()) {
+          throw std::runtime_error{"Unexpected is_connected() == true"};
+        }
+        if (db.ping_server()) {
+          throw std::runtime_error{"Unexpected ping_server() == true"};
+        }
+      }
+
+      template <typename Connection, typename ConfigPtr>
+      void test_conn_connected(const ConfigPtr& connection_config)
+      {
+        Connection db{connection_config};
+        if (db.is_connected() == false) {
+          throw std::runtime_error{"Unexpected is_connected() == false"};
+        }
+        if (db.ping_server() == false) {
+          throw std::runtime_error{"Unexpected ping_server() == false"};
+        }
+      }
+    }
+
+    template <typename Connection, typename ConfigPtr>
+    void test_normal_connection(const ConfigPtr& connection_config)
+    {
+      test_conn_empty<Connection>();
+      test_conn_connected<Connection>(connection_config);
+    }
+  }  // namespace test
+}  // namespace sqlpp

--- a/tests/mysql/usage/CMakeLists.txt
+++ b/tests/mysql/usage/CMakeLists.txt
@@ -40,6 +40,7 @@ set(test_files
     Truncated.cpp
     Update.cpp
     Remove.cpp
+    Connection.cpp
     ConnectionPool.cpp
 )
 

--- a/tests/mysql/usage/Connection.cpp
+++ b/tests/mysql/usage/Connection.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023, Vesselin Atanasov
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../../include/ConnectionTests.h"
+#include "make_test_connection.h"
+
+#include <sqlpp11/mysql/connection.h>
+#include <sqlpp11/sqlpp11.h>
+
+int Connection(int, char*[])
+{
+  namespace sql = sqlpp::mysql;
+  namespace test = sqlpp::test;
+
+  test::test_normal_connection<sql::connection>(sql::make_test_config());
+  return 0;
+}

--- a/tests/postgresql/usage/CMakeLists.txt
+++ b/tests/postgresql/usage/CMakeLists.txt
@@ -30,8 +30,8 @@ set(test_files
     Basic.cpp
     BasicConstConfig.cpp
     Blob.cpp
+    Connection.cpp
     ConnectionPool.cpp
-    Constructor.cpp
     Date.cpp
     DateTime.cpp
     Exceptions.cpp

--- a/tests/postgresql/usage/Connection.cpp
+++ b/tests/postgresql/usage/Connection.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, Serge Robyns
+ * Copyright (c) 2023, Vesselin Atanasov
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,
@@ -23,13 +24,17 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "../../include/ConnectionTests.h"
+#include "make_test_connection.h"
+
 #include <sqlpp11/postgresql/connection.h>
 #include <sqlpp11/sqlpp11.h>
 
-namespace sql = sqlpp::postgresql;
-
-int Constructor(int, char*[])
+int Connection(int, char*[])
 {
-  sql::connection db;
+  namespace sql = sqlpp::postgresql;
+  namespace test = sqlpp::test;
+
+  test::test_normal_connection<sql::connection>(sql::make_test_config());
   return 0;
 }

--- a/tests/sqlite3/usage/CMakeLists.txt
+++ b/tests/sqlite3/usage/CMakeLists.txt
@@ -38,6 +38,7 @@ set(test_files
     FloatingPoint.cpp
     Integral.cpp
     Blob.cpp
+    Connection.cpp
     ConnectionPool.cpp
 )
 

--- a/tests/sqlite3/usage/Connection.cpp
+++ b/tests/sqlite3/usage/Connection.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2023, Vesselin Atanasov
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "../../include/ConnectionTests.h"
+
+#include <sqlpp11/sqlite3/connection.h>
+#include <sqlpp11/sqlpp11.h>
+
+int Connection(int, char*[])
+{
+  namespace sql = sqlpp::sqlite3;
+  namespace test = sqlpp::test;
+
+  auto config = std::make_shared<sql::connection_config>();
+  config->path_to_database = ":memory:";
+  config->flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
+  config->debug = true;
+
+  test::test_normal_connection<sql::connection>(config);
+  return 0;
+}


### PR DESCRIPTION
This PR makes the following changes:

1. `is_connected()` method is added to the connection handles and the connection classes (both to normal and pooled connections). This method checks passively (without sending data to the server) if the connection is valid. For MySQL and SQLite3 connections it checks if the connection has been established. For PostgreSQL this method additionally calls `PQstatus`.
2. `ping_server()` method is added to the connection handles and the connection classes (both to normal and pooled connections). This method checks actively (by sending a request to the server) if the connection is valid. For MySQL it uses the MySQL client function `mysql_ping()`. For PostgreSQL and SQLite3 there are no such client library functions (actually libpq has `PGping()` but that function establishes a new connection to ping the server and we want to test an existing connection). So for PostgreSQL and SQLite3 their `ping_server()` methods are loosely based on the PHP function `pg_ping()` which sends `SELECT 1` to the server and checks if the server replies with a success.
3. There is a new enum `sqlpp::connection_check` which enumerates the three types of connection check: `none`, `passive` (i.e. `is_connected`) and `ping` (i.e. `ping_server`).
4. `connection_pool::get()` is changed to `connection_pool::get(connection_check check = connection_check::passive)`, that is when fetching a connection from the pool, the user can choose the check type that will be applied to the connection.

The PR was built and tested with
```
cmake -B build -DBUILD_POSTGRESQL_CONNECTOR=ON -DBUILD_SQLITE3_CONNECTOR=ON -DBUILD_MYSQL_CONNECTOR=ON -DBUILD_TESTING=ON -DUSE_SYSTEM_DATE=ON -DDEPENDENCY_CHECK=ON -DSQLPP11_TESTS_CXX_STD=11
```
All tests passed successfully.