### PR TITLE
Fix warning for `greater_equal` operator.

### DIFF
--- a/include/sqlpp11/basic_expression_operators.h
+++ b/include/sqlpp11/basic_expression_operators.h
@@ -171,7 +171,7 @@ namespace sqlpp
     auto operator>=(T t) const -> _new_binary_expression_t<greater_equal_t, T>
     {
       using rhs = wrap_operand_t<T>;
-      check_comparison_t<Expr, rhs>{};
+      check_comparison_t<Expr, rhs>::verify();
 
       return {*static_cast<const Expr*>(this), rhs{t}};
     }


### PR DESCRIPTION
Call `verify()` for `greater_equal` operator to fix `warning: expression result unused [-Wunused-value]`.