### PR TITLE
Fix warnings in ddl2cpp

### DIFF
--- a/scripts/ddl2cpp
+++ b/scripts/ddl2cpp
@@ -472,12 +472,12 @@ def repl_camel_case_func(m):
 
 def class_name_naming_func(s):
     s = s.replace(".", "_")
-    return re.sub("(^|\s|[_0-9])(\S)", repl_camel_case_func, s)
+    return re.sub(r"(^|\s|[_0-9])(\S)", repl_camel_case_func, s)
 
 
 def member_name_naming_func(s):
     s = s.replace(".", "_")
-    return re.sub("(\s|_|[0-9])(\S)", repl_camel_case_func, s)
+    return re.sub(r"(\s|_|[0-9])(\S)", repl_camel_case_func, s)
 
 
 def repl_func_for_args(m):
@@ -491,7 +491,7 @@ def setArgumentBool(s, bool_value):
     first_lower = (
         lambda s: s[:1].lower() + s[1:] if s else ""
     )  # http://stackoverflow.com/a/3847369/5006740
-    var_name = first_lower(re.sub("(\s|-|[0-9])(\S)", repl_func_for_args, s))
+    var_name = first_lower(re.sub(r"(\s|-|[0-9])(\S)", repl_func_for_args, s))
     globals()[var_name] = bool_value
 
 def loadExtendedTypesFile(filename):


### PR DESCRIPTION
There are a three regular expressions in `ddl2cpp` which lack proper escaping and  Python 3.12.0 generates warnings.
```
/usr/local/bin/sqlpp11-ddl2cpp:475: SyntaxWarning: invalid escape sequence '\s'
  return re.sub("(^|\s|[_0-9])(\S)", repl_camel_case_func, s)
/usr/local/bin/sqlpp11-ddl2cpp:480: SyntaxWarning: invalid escape sequence '\s'
  return re.sub("(\s|_|[0-9])(\S)", repl_camel_case_func, s)
/usr/local/bin/sqlpp11-ddl2cpp:494: SyntaxWarning: invalid escape sequence '\s'
  var_name = first_lower(re.sub("(\s|-|[0-9])(\S)", repl_func_for_args, s))
```

 Right now it is a minor issue as Python automatically adds the missing backslashes to the regular expressions, but recently they changed these warnings from `DeprecationWarning` to `SyntaxWarning` and it seems that they are planning to make them errors further down the road.

This PR fixes the warnings by adding the missing backslashes.