### PR TITLE
PostgreSQL exceptions for serialization_failure and deadlock_detected

### DIFF
--- a/include/sqlpp11/postgresql/exception.h
+++ b/include/sqlpp11/postgresql/exception.h
@@ -299,6 +299,17 @@ namespace sqlpp
       }
     };
 
+    class DLL_PUBLIC deadlock_detected : public sql_error
+    {
+    public:
+      explicit deadlock_detected(std::string err) : sql_error{std::move(err)}
+      {
+      }
+      deadlock_detected(std::string err, std::string Q) : sql_error{std::move(err), std::move(Q)}
+      {
+      }
+    };
+
     class DLL_PUBLIC syntax_error : public sql_error
     {
     public:

--- a/include/sqlpp11/postgresql/exception.h
+++ b/include/sqlpp11/postgresql/exception.h
@@ -288,6 +288,17 @@ namespace sqlpp
       }
     };
 
+    class DLL_PUBLIC serialization_failure : public sql_error
+    {
+    public:
+      explicit serialization_failure(std::string err) : sql_error{std::move(err)}
+      {
+      }
+      serialization_failure(std::string err, std::string Q) : sql_error{std::move(err), std::move(Q)}
+      {
+      }
+    };
+
     class DLL_PUBLIC syntax_error : public sql_error
     {
     public:

--- a/include/sqlpp11/postgresql/result.h
+++ b/include/sqlpp11/postgresql/result.h
@@ -245,6 +245,9 @@ namespace sqlpp
             case '4':
               switch (code[1])
               {
+                case '0':
+                  if (strcmp(code, "40001") == 0)
+                    throw serialization_failure{err, query};
                 case '2':
                   if (strcmp(code, "42501") == 0)
                     throw insufficient_privilege{err, query};

--- a/include/sqlpp11/postgresql/result.h
+++ b/include/sqlpp11/postgresql/result.h
@@ -248,6 +248,8 @@ namespace sqlpp
                 case '0':
                   if (strcmp(code, "40001") == 0)
                     throw serialization_failure{err, query};
+                  if (strcmp(code, "40P01") == 0)
+                    throw deadlock_detected{err, query};
                 case '2':
                   if (strcmp(code, "42501") == 0)
                     throw insufficient_privilege{err, query};


### PR DESCRIPTION
This PR adds exception classes for PostgreSQL errors

40001 (serialization_failure)
40P01 (deadlock_detected)

Handling these error codes is useful when implementing optimistic locking where transactions are expected to fail sometimes with certain error codes and such transactions should be retried (semi-)automatically.

Overall the exception hierarchy of sqlpp needs an overhaul to allow a common implementation that would cover all connectors at once. This PR is more or less a temporary band-aid to make optimistic locking easier to implement with PostgreSQL.