### PR TITLE
Missing break when throwing PostgreSQL transaction exceptions

### DIFF
--- a/include/sqlpp11/postgresql/result.h
+++ b/include/sqlpp11/postgresql/result.h
@@ -250,6 +250,7 @@ namespace sqlpp
                     throw serialization_failure{err, query};
                   if (strcmp(code, "40P01") == 0)
                     throw deadlock_detected{err, query};
+                  break;
                 case '2':
                   if (strcmp(code, "42501") == 0)
                     throw insufficient_privilege{err, query};


### PR DESCRIPTION
The previous PR that added support for PostgreSQL transaction exceptions (https://github.com/rbock/sqlpp11/pull/551) lacks a break statement in the newly added switch case. This does not cause any bugs but leads to slightly inefficient code and causes compiler warnings about the unintentional fall-through. 

I am not sure why I missed the warning previously, but here is the PR that fixes it. As usual it was built and tested with
```
cmake -B build -DBUILD_POSTGRESQL_CONNECTOR=ON -DBUILD_SQLITE3_CONNECTOR=ON -DBUILD_MYSQL_CONNECTOR=ON -DBUILD_TESTING=ON -DUSE_SYSTEM_DATE=ON -DDEPENDENCY_CHECK=ON
cmake --build build
cd build
ctest
```
All tests passed successfully.