### PR TITLE
Update FindMariaDB.cmake

### DIFF
--- a/cmake/modules/FindMariaDB.cmake
+++ b/cmake/modules/FindMariaDB.cmake
@@ -43,7 +43,10 @@ else()
         NAMES mariadb_version.h
         PATH_SUFFIXES mariadb mysql
     )
-    find_library(MariaDB_LIBRARY NAMES mariadb)
+    find_library(MariaDB_LIBRARY 
+        NAMES mariadb
+        PATH_SUFFIXES mariadb mysql
+    )
 endif()
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
Users can use 
-DCMAKE_LIBRARY_PATH=${INSTALL}/lib
 without needing to specify mariadb separately like 
-DCMAKE_LIBRARY_PATH=${INSTALL}/lib/mariadb