### PR TITLE
Recognize serial2, serial4 and serial8 types in ddl2cpp

### DIFF
--- a/scripts/ddl2cpp
+++ b/scripts/ddl2cpp
@@ -92,6 +92,9 @@ ddlIntegerTypes = [
 ddlSerialTypes = [
     "bigserial",  # PostgreSQL
     "serial",  # PostgreSQL
+    "serial2",  # PostgreSQL
+    "serial4",  # PostgreSQL
+    "serial8",  # PostgreSQL
     "smallserial",  # PostgreSQL
 ]
 
@@ -233,6 +236,9 @@ def initDllParser():
         "AUTOINCREMENT",
         "SMALLSERIAL",
         "SERIAL",
+        "SERIAL2",
+        "SERIAL4",
+        "SERIAL8",
         "BIGSERIAL",
         "GENERATED",
     ]


### PR DESCRIPTION
While trying to make primary key columns NOT NULL, I came across another limitation of ddl2cpp. It does not recognize the PostgreSQL-specific data types serial2, serial4 and serial8.

When it comes across an unknown column type (like one of these serial types), ddl2cpp ignores any column modifiers like NOT NULL, PRIMARY KEY, etc.

This is a quick fix that adds support for the three data types.

One might argue that the correct behavior when coming across an unknown data type would be just to terminate the script with error, but this could break things  in the future when some of the databases adds a new data type or an alias for an existing data type.