### PR TITLE
Fix SQL keyword matching in ddl2cpp

### DIFF
--- a/scripts/ddl2cpp
+++ b/scripts/ddl2cpp
@@ -45,7 +45,8 @@ ddlString = (
 ddlTerm = pp.Word(pp.alphas + "_", pp.alphanums + "_.$")
 ddlName = pp.Or([ddlTerm, ddlString, pp.Combine(ddlString + "." + ddlString), pp.Combine(ddlTerm + ddlString)])
 ddlOperator = pp.Or(
-    map(pp.CaselessLiteral, ["+", "-", "*", "/", "<", "<=", ">", ">=", "=", "%", "DIV"])
+    map(pp.CaselessLiteral, ["+", "-", "*", "/", "<", "<=", ">", ">=", "=", "%"]),
+    pp.CaselessKeyword("DIV")
 )
 
 ddlBracedExpression = pp.Forward()
@@ -162,44 +163,44 @@ def initDllParser():
     # Column and constraint parsers
 
     ddlBoolean = pp.Or(
-        map(pp.CaselessLiteral, sorted(ddlBooleanTypes, reverse=True))
+        map(pp.CaselessKeyword, sorted(ddlBooleanTypes, reverse=True))
     ).setParseAction(pp.replaceWith("boolean"))
 
     ddlInteger = pp.Or(
-        map(pp.CaselessLiteral, sorted(ddlIntegerTypes, reverse=True))
+        map(pp.CaselessKeyword, sorted(ddlIntegerTypes, reverse=True))
     ).setParseAction(pp.replaceWith("integer"))
 
     ddlSerial = (
-        pp.Or(map(pp.CaselessLiteral, sorted(ddlSerialTypes, reverse=True)))
+        pp.Or(map(pp.CaselessKeyword, sorted(ddlSerialTypes, reverse=True)))
         .setParseAction(pp.replaceWith("integer"))
         .setResultsName("hasAutoValue")
     )
 
     ddlFloatingPoint = pp.Or(
-        map(pp.CaselessLiteral, sorted(ddlFloatingPointTypes, reverse=True))
+        map(pp.CaselessKeyword, sorted(ddlFloatingPointTypes, reverse=True))
     ).setParseAction(pp.replaceWith("floating_point"))
 
     ddlText = pp.Or(
-        map(pp.CaselessLiteral, sorted(ddlTextTypes, reverse=True))
+        map(pp.CaselessKeyword, sorted(ddlTextTypes, reverse=True))
     ).setParseAction(pp.replaceWith("text"))
 
 
     ddlBlob = pp.Or(
-        map(pp.CaselessLiteral, sorted(ddlBlobTypes, reverse=True))
+        map(pp.CaselessKeyword, sorted(ddlBlobTypes, reverse=True))
     ).setParseAction(pp.replaceWith("blob"))
 
     ddlDate = (
-        pp.Or(map(pp.CaselessLiteral, sorted(ddlDateTypes, reverse=True)))
+        pp.Or(map(pp.CaselessKeyword, sorted(ddlDateTypes, reverse=True)))
         .setParseAction(pp.replaceWith("day_point"))
         .setResultsName("warnTimezone")
     )
 
     ddlDateTime = pp.Or(
-        map(pp.CaselessLiteral, sorted(ddlDateTimeTypes, reverse=True))
+        map(pp.CaselessKeyword, sorted(ddlDateTimeTypes, reverse=True))
     ).setParseAction(pp.replaceWith("time_point"))
 
     ddlTime = pp.Or(
-        map(pp.CaselessLiteral, sorted(ddlTimeTypes, reverse=True))
+        map(pp.CaselessKeyword, sorted(ddlTimeTypes, reverse=True))
     ).setParseAction(pp.replaceWith("time_of_day"))
 
     ddlUnknown = pp.Word(pp.alphanums).setParseAction(pp.replaceWith("UNKNOWN"))
@@ -217,19 +218,19 @@ def initDllParser():
         | ddlUnknown
     )
 
-    ddlUnsigned = pp.CaselessLiteral("UNSIGNED").setResultsName("isUnsigned")
+    ddlUnsigned = pp.CaselessKeyword("UNSIGNED").setResultsName("isUnsigned")
     ddlDigits = "," + pp.Word(pp.nums)
     ddlWidth = ddlLeft + pp.Word(pp.nums) + pp.Optional(ddlDigits) + ddlRight
     ddlTimezone = (
-        (pp.CaselessLiteral("with") | pp.CaselessLiteral("without"))
-        + pp.CaselessLiteral("time")
-        + pp.CaselessLiteral("zone")
+        (pp.CaselessKeyword("with") | pp.CaselessKeyword("without"))
+        + pp.CaselessKeyword("time")
+        + pp.CaselessKeyword("zone")
     )
 
     ddlNotNull = pp.Group(
-        pp.CaselessLiteral("NOT") + pp.CaselessLiteral("NULL")
+        pp.CaselessKeyword("NOT") + pp.CaselessKeyword("NULL")
     ).setResultsName("notNull")
-    ddlDefaultValue = pp.CaselessLiteral("DEFAULT").setResultsName("hasDefaultValue")
+    ddlDefaultValue = pp.CaselessKeyword("DEFAULT").setResultsName("hasDefaultValue")
 
     ddlAutoKeywords = [
         "AUTO_INCREMENT",
@@ -242,7 +243,7 @@ def initDllParser():
         "BIGSERIAL",
         "GENERATED",
     ]
-    ddlAutoValue = pp.Or(map(pp.CaselessLiteral, sorted(ddlAutoKeywords, reverse=True)))
+    ddlAutoValue = pp.Or(map(pp.CaselessKeyword, sorted(ddlAutoKeywords, reverse=True)))
 
     ddlConstraintKeywords = [
         "CONSTRAINT",
@@ -256,7 +257,7 @@ def initDllParser():
         "PERIOD",
     ]
     ddlConstraint = pp.Group(
-        pp.Or(map(pp.CaselessLiteral, sorted(ddlConstraintKeywords, reverse=True)))
+        pp.Or(map(pp.CaselessKeyword, sorted(ddlConstraintKeywords, reverse=True)))
         + ddlExpression
     ).setResultsName("isConstraint")
 
@@ -268,25 +269,25 @@ def initDllParser():
         + pp.ZeroOrMore(
             ddlUnsigned("isUnsigned")
             | ddlNotNull("notNull")
-            | pp.CaselessLiteral("null")
+            | pp.CaselessKeyword("null")
             | ddlAutoValue("hasAutoValue")
             | ddlDefaultValue("hasDefaultValue")
-            | pp.Suppress(pp.OneOrMore(pp.Or(map(pp.CaselessLiteral, sorted(ddlConstraintKeywords, reverse=True)))))
+            | pp.Suppress(pp.OneOrMore(pp.Or(map(pp.CaselessKeyword, sorted(ddlConstraintKeywords, reverse=True)))))
             | pp.Suppress(ddlExpression)
         )
     )
 
     # CREATE TABLE parser
     ddlIfNotExists = pp.Group(
-        pp.CaselessLiteral("IF") + pp.CaselessLiteral("NOT") + pp.CaselessLiteral("EXISTS")
+        pp.CaselessKeyword("IF") + pp.CaselessKeyword("NOT") + pp.CaselessKeyword("EXISTS")
     ).setResultsName("ifNotExists")
     ddlOrReplace = pp.Group(
-        pp.CaselessLiteral("OR") + pp.CaselessLiteral("REPLACE")
+        pp.CaselessKeyword("OR") + pp.CaselessKeyword("REPLACE")
     ).setResultsName("orReplace")
     ddlCreateTable = pp.Group(
-        pp.CaselessLiteral("CREATE")
+        pp.CaselessKeyword("CREATE")
         + pp.Suppress(pp.Optional(ddlOrReplace))
-        + pp.CaselessLiteral("TABLE")
+        + pp.CaselessKeyword("TABLE")
         + pp.Suppress(pp.Optional(ddlIfNotExists))
         + ddlName.setResultsName("tableName")
         + ddlLeft

--- a/tests/scripts/CMakeLists.txt
+++ b/tests/scripts/CMakeLists.txt
@@ -54,7 +54,7 @@ if (${Python3_Interpreter_FOUND})
                     "${CMAKE_CURRENT_LIST_DIR}/ddl2cpp_sample_bad.sql"
                     "${CMAKE_CURRENT_BINARY_DIR}/fail"
                     test)
-        set_tests_properties(sqlpp11.scripts.ddl2cpp.bad_has_parse_error PROPERTIES 
+        set_tests_properties(sqlpp11.scripts.ddl2cpp.bad_has_parse_error PROPERTIES
             PASS_REGULAR_EXPRESSION "ERROR: Could not parse.*")
 
         add_test(NAME sqlpp11.scripts.ddl2cpp.good_succeeds
@@ -63,9 +63,10 @@ if (${Python3_Interpreter_FOUND})
                     "${CMAKE_CURRENT_BINARY_DIR}/fail"
                     test)
 
+        include_directories(${CMAKE_CURRENT_BINARY_DIR})
+
         foreach(sample_name sample sample_identity_naming)
             set(sqlpp.scripts.generated.sample.include "${CMAKE_CURRENT_BINARY_DIR}/${sample_name}")
-            include_directories(${CMAKE_CURRENT_BINARY_DIR})
             set(use_identity_naming)
             if(sample_name STREQUAL "sample_identity_naming")
                 set(use_identity_naming -identity-naming)
@@ -80,21 +81,27 @@ if (${Python3_Interpreter_FOUND})
                 DEPENDS "${CMAKE_CURRENT_LIST_DIR}/ddl2cpp_sample_good.sql"
                 VERBATIM)
 
-            add_executable(sqlpp.scripts.compiled.${sample_name} ${sample_name}.cpp 
+            add_executable(sqlpp.scripts.compiled.${sample_name} ${sample_name}.cpp
                 "${sqlpp.scripts.generated.sample.include}.h")
             target_link_libraries(sqlpp.scripts.compiled.${sample_name} PRIVATE sqlpp11)
         endforeach()
 
-        set(custom_type_sql "ddl2cpp_sample_good_custom_type")
-        include_directories(${CMAKE_CURRENT_BINARY_DIR})
-        add_test(NAME sqlpp11.scripts.ddl2cpp.bad_custom_types
-            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../../scripts/ddl2cpp"
-                    "${CMAKE_CURRENT_LIST_DIR}/${custom_type_sql}.sql"
-                    "${CMAKE_CURRENT_BINARY_DIR}/fail"
-                    test)
-        set_tests_properties(sqlpp11.scripts.ddl2cpp.bad_custom_types PROPERTIES
-            PASS_REGULAR_EXPRESSION "Error: unsupported datatypes.")
+        # Invalid .types names
+        # TODO: Read the types from a text file and generate the input .sql files in the build directory
+        foreach(bad_type "booltype" "invalid" "serial5" "typeint")
+#            message(STATUS "${bad_type}")
+            set(bad_type_test_name "sqlpp11.scripts.ddl2cpp.bad_type.${bad_type}")
+            add_test(NAME "${bad_type_test_name}"
+                COMMAND "${Python3_EXECUTABLE}" "${CMAKE_CURRENT_LIST_DIR}/../../scripts/ddl2cpp"
+                        "${CMAKE_CURRENT_LIST_DIR}/ddl2cpp_sample_bad_type_${bad_type}.sql"
+                        "${CMAKE_CURRENT_BINARY_DIR}/fail"
+                        test)
+            set_tests_properties("${bad_type_test_name}" PROPERTIES
+                PASS_REGULAR_EXPRESSION "Error: unsupported datatypes.")
+        endforeach()
 
+        # Custom types defined in a CSV file
+        set(custom_type_sql "ddl2cpp_sample_good_custom_type")
         set(sqlpp.scripts.generated.custom_type_sql.include "${CMAKE_CURRENT_BINARY_DIR}/${custom_type_sql}")
         add_custom_command(
             OUTPUT "${sqlpp.scripts.generated.custom_type_sql.include}.h"
@@ -105,7 +112,6 @@ if (${Python3_Interpreter_FOUND})
                     test
             DEPENDS "${CMAKE_CURRENT_LIST_DIR}/${custom_type_sql}.sql"
             VERBATIM)
-
         add_executable(sqlpp.scripts.compiled.${custom_type_sql} ${custom_type_sql}.cpp
             "${sqlpp.scripts.generated.custom_type_sql.include}.h")
         target_link_libraries(sqlpp.scripts.compiled.${custom_type_sql} PRIVATE sqlpp11)

--- a/tests/scripts/ddl2cpp_sample_bad_type_booltype.sql
+++ b/tests/scripts/ddl2cpp_sample_bad_type_booltype.sql
@@ -1,0 +1,1 @@
+CREATE TABLE mytable (mycol booltype);

--- a/tests/scripts/ddl2cpp_sample_bad_type_invalid.sql
+++ b/tests/scripts/ddl2cpp_sample_bad_type_invalid.sql
@@ -1,0 +1,1 @@
+CREATE TABLE mytable (mycol invalid);

--- a/tests/scripts/ddl2cpp_sample_bad_type_serial5.sql
+++ b/tests/scripts/ddl2cpp_sample_bad_type_serial5.sql
@@ -1,0 +1,1 @@
+CREATE TABLE mytable (mycol serial5);

--- a/tests/scripts/ddl2cpp_sample_bad_type_typeint.sql
+++ b/tests/scripts/ddl2cpp_sample_bad_type_typeint.sql
@@ -1,0 +1,1 @@
+CREATE TABLE mytable (mycol typeint);


### PR DESCRIPTION
Normally ddl2cpp terminates with an error message if the input .sql script has a column with an unknown data type. However it does not err if there is a valid data type which is a prefix of the unknown data type.

For example ddl2cpp will err for the unknown data type `invalidtype`, but will not err for `serial5`, because its prefix, `serial` is a valid data type. In the latter case the ddl2cpp parse will consume the prefix `serial` while the remainder `5` will not cause an error, but will cause the parser to ignore valid modifiers, like `NOT NULL`, `DEFAULT`, etc.

The cause of the bug is that ddl2cpp uses `pp.CaselessLiteral` to match keywords, while it should actually use `pp.CaselessKeyword`. The former matches any valid prefix, not paying attention to word boundaries. While the latter matches only whole words.

This PR fixes the bug and causes dddl2cpp to always err for invalid data types and it also fixes other similar problems caused by the use of `pp.CaselessLiteral`. The PR also improves the testing for invalid data types.