### PR TITLE
ddl2cpp: primary key column cannot be null

### DIFF
--- a/scripts/ddl2cpp
+++ b/scripts/ddl2cpp
@@ -245,9 +245,12 @@ def initDllParser():
     ]
     ddlAutoValue = pp.Or(map(pp.CaselessKeyword, sorted(ddlAutoKeywords, reverse=True)))
 
-    ddlConstraintKeywords = [
+    ddlPrimaryKey = pp.Group(
+        pp.CaselessKeyword("PRIMARY") + pp.CaselessKeyword("KEY")
+    ).setResultsName("isPrimaryKey")
+
+    ddlIgnoredKeywords = [
         "CONSTRAINT",
-        "PRIMARY",
         "FOREIGN",
         "KEY",
         "FULLTEXT",
@@ -257,7 +260,10 @@ def initDllParser():
         "PERIOD",
     ]
     ddlConstraint = pp.Group(
-        pp.Or(map(pp.CaselessKeyword, sorted(ddlConstraintKeywords, reverse=True)))
+        pp.Or(map(
+            pp.CaselessKeyword,
+            sorted(ddlIgnoredKeywords + ["PRIMARY"], reverse=True)
+        ))
         + ddlExpression
     ).setResultsName("isConstraint")
 
@@ -272,7 +278,8 @@ def initDllParser():
             | pp.CaselessKeyword("null")
             | ddlAutoValue("hasAutoValue")
             | ddlDefaultValue("hasDefaultValue")
-            | pp.Suppress(pp.OneOrMore(pp.Or(map(pp.CaselessKeyword, sorted(ddlConstraintKeywords, reverse=True)))))
+            | ddlPrimaryKey("isPrimaryKey")
+            | pp.Suppress(pp.OneOrMore(pp.Or(map(pp.CaselessKeyword, sorted(ddlIgnoredKeywords, reverse=True)))))
             | pp.Suppress(ddlExpression)
         )
     )
@@ -714,7 +721,7 @@ def createHeader():
                 traitslist.append("sqlpp::tag::must_not_insert")
                 traitslist.append("sqlpp::tag::must_not_update")
                 requireInsert = False
-            if not column.notNull:
+            if not column.notNull and not column.isPrimaryKey:
                 traitslist.append("sqlpp::tag::can_be_null")
                 requireInsert = False
             if column.hasDefaultValue:

--- a/scripts/ddl2cpp
+++ b/scripts/ddl2cpp
@@ -386,6 +386,7 @@ def testColumn():
     assert column.isUnsigned
     assert column.notNull
     assert not column.hasAutoValue
+    assert not column.isPrimaryKey
 
 
 def testConstraint():
@@ -445,6 +446,7 @@ def testPrimaryKeyAutoIncrement():
         assert column.type == "integer"
         assert column.notNull
         assert column.hasAutoValue
+        assert column.isPrimaryKey
 
 def testParser():
     initDllParser()


### PR DESCRIPTION
This PR updates ddl2cpp so that columns with the `PRIMARY KEY` constraint never get the `sqlpp::tag::can_be_null` tag.

The PR only affects `PRIMARY KEY` constraints on column level. A `PRIMARY KEY` constraint defined on a table level (after column definitions), still can get the `sqlpp::tag::can_be_null` tag. In order to fix that for table-level constraints more changes to the codebase would be needed.