### PR TITLE
Comment a limitation of result_t::iterator::operator++(int)

### DIFF
--- a/include/sqlpp11/result.h
+++ b/include/sqlpp11/result.h
@@ -127,9 +127,8 @@ namespace sqlpp
 
       iterator operator++(int)
       {
-        auto previous_it = *this;
-        _result.next(_result_row.get());
-        return previous_it;
+        // FIXME: Currently the postfix increment operator does a prefix increment
+        return ++*this;
       }
 
       std::reference_wrapper<db_result_t> _result;


### PR DESCRIPTION
As per our discussion here https://github.com/rbock/sqlpp11/issues/591 this PR makes result_t::iterator::operator++(int) an alias of result_t::iterator::operator++() and add a comment about its limitation.

The PR was built and tested with:
```
cmake -B build -DBUILD_POSTGRESQL_CONNECTOR=ON -DBUILD_SQLITE3_CONNECTOR=ON -DBUILD_MYSQL_CONNECTOR=ON -DBUILD_TESTING=ON -DUSE_SYSTEM_DATE=ON -DDEPENDENCY_CHECK=ON
cmake --build build
cd build
ctest
```
All tests passed successfully.