### PR TITLE
Turn result_t into a C++20 range

### DIFF
--- a/include/sqlpp11/result.h
+++ b/include/sqlpp11/result.h
@@ -81,7 +81,14 @@ namespace sqlpp
     class iterator
     {
     public:
+#if __cplusplus >= 202002L
+      using iterator_concept = std::input_iterator_tag;
+#else
+      // LegacyInputIterator describes best our iterator's capabilities. However our iterator does not
+      // really fulfil the requirements for LegacyInputIterator because its post-increment operator
+      // returns void.
       using iterator_category = std::input_iterator_tag;
+#endif
       using value_type = result_row_t;
       using pointer = const result_row_t*;
       using reference = const result_row_t&;
@@ -133,10 +140,8 @@ namespace sqlpp
 
       // It is quite difficult to implement a postfix increment operator that returns the old iterator
       // because the underlying database results work in a stream fashion not allowing to return to
-      // previously-read rows.
-      //
-      // We need the postfix increment mostly for compatibility with C++20 ranges so we set the return
-      // type to "void" which is allowed for C++20 range iterators.
+      // previously-read rows. That is why we set the post-increment return type to void, which is
+      // allowed for C++20 input iterators
       //
       void operator++(int)
       {

--- a/include/sqlpp11/result.h
+++ b/include/sqlpp11/result.h
@@ -93,6 +93,11 @@ namespace sqlpp
       using reference = const result_row_t&;
       using difference_type = std::ptrdiff_t;
 
+      iterator()
+          : _result_ptr(nullptr), _result_row_ptr(nullptr)
+      {
+      }
+
       iterator(db_result_t& result, result_row_t& result_row)
           : _result_ptr(&result), _result_row_ptr(&result_row)
       {
@@ -110,6 +115,14 @@ namespace sqlpp
 
       bool operator==(const iterator& rhs) const
       {
+        if ((_result_row_ptr != nullptr) != (rhs._result_row_ptr != nullptr))
+        {
+          return false;
+        }
+        if (_result_row_ptr == nullptr)
+        {
+          return true;
+        }
         return *_result_row_ptr == *rhs._result_row_ptr;
       }
 

--- a/include/sqlpp11/result.h
+++ b/include/sqlpp11/result.h
@@ -32,12 +32,6 @@
 
 namespace sqlpp
 {
-  template <typename>
-  struct iterator_category
-  {
-    using type = std::input_iterator_tag;
-  };
-
   namespace detail
   {
     template<class DbResult, class = void>
@@ -87,7 +81,7 @@ namespace sqlpp
     class iterator
     {
     public:
-      using iterator_category = typename iterator_category<DbResult>::type;
+      using iterator_category = std::input_iterator_tag;
       using value_type = result_row_t;
       using pointer = const result_row_t*;
       using reference = const result_row_t&;

--- a/include/sqlpp11/result.h
+++ b/include/sqlpp11/result.h
@@ -93,25 +93,24 @@ namespace sqlpp
       using reference = const result_row_t&;
       using difference_type = std::ptrdiff_t;
 
-      iterator(std::reference_wrapper<db_result_t> result,
-               std::reference_wrapper<result_row_t> result_row) :
-          _result(std::move(result)), _result_row(std::move(result_row))
+      iterator(db_result_t& result, result_row_t& result_row)
+          : _result_ptr(&result), _result_row_ptr(&result_row)
       {
       }
 
       reference operator*() const
       {
-        return _result_row;
+        return *_result_row_ptr;
       }
 
       pointer operator->() const
       {
-        return &_result_row.get();
+        return _result_row_ptr;
       }
 
       bool operator==(const iterator& rhs) const
       {
-        return _result_row.get() == rhs._result_row.get();
+        return *_result_row_ptr == *rhs._result_row_ptr;
       }
 
       bool operator!=(const iterator& rhs) const
@@ -121,7 +120,7 @@ namespace sqlpp
 
       iterator& operator++()
       {
-        _result.get().next(_result_row.get());
+        _result_ptr->next(*_result_row_ptr);
         return *this;
       }
 
@@ -137,18 +136,19 @@ namespace sqlpp
         ++*this;
       }
 
-      std::reference_wrapper<db_result_t> _result;
-      std::reference_wrapper<result_row_t> _result_row;
+      // Use T* instead of T& for default-constructibility
+      db_result_t* _result_ptr;
+      result_row_t* _result_row_ptr;
     };
 
     iterator begin()
     {
-      return iterator(std::ref(_result), std::ref(_result_row));
+      return iterator(_result, _result_row);
     }
 
     iterator end()
     {
-      return iterator(std::ref(_end), std::ref(_end_row));
+      return iterator(_end, _end_row);
     }
 
     const result_row_t& front() const

--- a/include/sqlpp11/result.h
+++ b/include/sqlpp11/result.h
@@ -125,11 +125,16 @@ namespace sqlpp
         return *this;
       }
 
-      iterator operator++(int)
+      // It is quite difficult to implement a postfix increment operator that returns the old iterator
+      // because the underlying database results work in a stream fashion not allowing to return to
+      // previously-read rows.
+      //
+      // We need the postfix increment mostly for compatibility with C++20 ranges so we set the return
+      // type to "void" which is allowed for C++20 range iterators.
+      //
+      void operator++(int)
       {
-        auto previous_it = *this;
-        _result.next(_result_row.get());
-        return previous_it;
+        ++*this;
       }
 
       std::reference_wrapper<db_result_t> _result;


### PR DESCRIPTION
This PR turns `result_t` objects into C++20 ranges that can be used with various range/view algorithms. Since C++20 views are essentially movable ranges and `result_t` is movable, this means that `result_t` is also a view.

C++20 input ranges are single-pass, i.e. they are only required to support a single call to `begin()` and range algorithms are prohibited from calling `begin()` a second time on an input range. This requirement fits quite well the way sqlpp11's database results behave, because they are single-pass too.

The PR makes two main changes to `result_t::iterator`

- The return type of the postfix increment operator is changed to `void`. To facilitate the use of postfix increment with input ranges, their postfix increment operator is allowed (and actually recommended) to return `void`.
- The iterator is made default-constructible. To achieve that its references to the result data and result row are changed to pointers. For default-constructed iterators these pointers are set to `nullptr`.

The PR also adds a comment about `result_t::iterator::operator==`, which allows comparison of iterators that don't belong to the same sequence (i.e. database result). Such comparison is undefined behavior by the standard, but the old code allowed it. The updated code also allows that, but I added a comment about it. It should probably be fixed further down the road, but such a fix would be too intrusive, so I decided just to document it.