### PR TITLE
Fix C++ standard check on MSVC

### DIFF
--- a/include/sqlpp11/compat/cxx_std_ver.h
+++ b/include/sqlpp11/compat/cxx_std_ver.h
@@ -1,7 +1,0 @@
-#pragma once
-
-#ifdef _MSVC_LANG
-#define CXX_STD_VER _MSVC_LANG
-#else
-#define CXX_STD_VER __cplusplus
-#endif

--- a/include/sqlpp11/compat/cxx_std_ver.h
+++ b/include/sqlpp11/compat/cxx_std_ver.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#ifdef _MSVC_LANG
+#define CXX_STD_VER _MSVC_LANG
+#else
+#define CXX_STD_VER __cplusplus
+#endif

--- a/include/sqlpp11/compat/make_unique.h
+++ b/include/sqlpp11/compat/make_unique.h
@@ -26,13 +26,9 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <memory>
+#include <sqlpp11/compat/cxx_std_ver.h>
 
-#ifdef _MSVC_LANG
-#define CXX_STD_VER _MSVC_LANG
-#else
-#define CXX_STD_VER __cplusplus
-#endif
+#include <memory>
 
 namespace sqlpp
 {

--- a/include/sqlpp11/compat/make_unique.h
+++ b/include/sqlpp11/compat/make_unique.h
@@ -26,7 +26,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sqlpp11/compat/cxx_std_ver.h>
+#include <sqlpp11/compat/sqlpp_cxx_std.h>
 
 #include <memory>
 
@@ -37,7 +37,7 @@ namespace sqlpp
     template <typename T, typename... Args>
     std::unique_ptr<T> make_unique(Args&&... args)
     {
-#if CXX_STD_VER >= 201402L
+#if SQLPP_CXX_STD >= 201402L
       return std::make_unique<T>(std::forward<Args>(args)...);
 #else
       return std::unique_ptr<T>(new T(std::forward<Args>(args)...));

--- a/include/sqlpp11/compat/sqlpp_cxx_std.h
+++ b/include/sqlpp11/compat/sqlpp_cxx_std.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#ifdef _MSVC_LANG
+#define SQLPP_CXX_STD _MSVC_LANG
+#else
+#define SQLPP_CXX_STD __cplusplus
+#endif

--- a/include/sqlpp11/data_types/text/operand.h
+++ b/include/sqlpp11/data_types/text/operand.h
@@ -26,9 +26,11 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <sqlpp11/compat/cxx_std_ver.h>
+
 #include <string>
 #include <utility>
-#if __cplusplus >= 201703L
+#if CXX_STD_VER >= 201703L
 #include <string_view>
 #endif
 #include <sqlpp11/type_traits.h>
@@ -51,7 +53,7 @@ namespace sqlpp
     text_operand(_value_t t) : _t(std::move(t))
     {
     }
-#if __cplusplus >= 201703L
+#if CXX_STD_VER >= 201703L
     // allow construction from an std::string_view
     text_operand(std::string_view t) : _t(t)
     {

--- a/include/sqlpp11/data_types/text/operand.h
+++ b/include/sqlpp11/data_types/text/operand.h
@@ -26,11 +26,11 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sqlpp11/compat/cxx_std_ver.h>
+#include <sqlpp11/compat/sqlpp_cxx_std.h>
 
 #include <string>
 #include <utility>
-#if CXX_STD_VER >= 201703L
+#if SQLPP_CXX_STD >= 201703L
 #include <string_view>
 #endif
 #include <sqlpp11/type_traits.h>
@@ -53,7 +53,7 @@ namespace sqlpp
     text_operand(_value_t t) : _t(std::move(t))
     {
     }
-#if CXX_STD_VER >= 201703L
+#if SQLPP_CXX_STD >= 201703L
     // allow construction from an std::string_view
     text_operand(std::string_view t) : _t(t)
     {

--- a/include/sqlpp11/data_types/text/parameter_value.h
+++ b/include/sqlpp11/data_types/text/parameter_value.h
@@ -26,13 +26,15 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <sqlpp11/compat/cxx_std_ver.h>
+
 #include <sqlpp11/data_types/parameter_value.h>
 #include <sqlpp11/data_types/parameter_value_base.h>
 #include <sqlpp11/data_types/text/data_type.h>
 #include <sqlpp11/data_types/text/wrap_operand.h>
 #include <sqlpp11/data_types/text/operand.h>
 
-#if __cplusplus >= 201703L
+#if CXX_STD_VER >= 201703L
 #include <string_view>
 #endif
 
@@ -51,7 +53,7 @@ namespace sqlpp
       target._bind_text_parameter(index, &_value, _is_null);
     }
 
-#if __cplusplus >= 201703L
+#if CXX_STD_VER >= 201703L
     parameter_value_base& operator=(const std::string_view& val)
     {
       _value = val;

--- a/include/sqlpp11/data_types/text/parameter_value.h
+++ b/include/sqlpp11/data_types/text/parameter_value.h
@@ -26,7 +26,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sqlpp11/compat/cxx_std_ver.h>
+#include <sqlpp11/compat/sqlpp_cxx_std.h>
 
 #include <sqlpp11/data_types/parameter_value.h>
 #include <sqlpp11/data_types/parameter_value_base.h>
@@ -34,7 +34,7 @@
 #include <sqlpp11/data_types/text/wrap_operand.h>
 #include <sqlpp11/data_types/text/operand.h>
 
-#if CXX_STD_VER >= 201703L
+#if SQLPP_CXX_STD >= 201703L
 #include <string_view>
 #endif
 
@@ -53,7 +53,7 @@ namespace sqlpp
       target._bind_text_parameter(index, &_value, _is_null);
     }
 
-#if CXX_STD_VER >= 201703L
+#if SQLPP_CXX_STD >= 201703L
     parameter_value_base& operator=(const std::string_view& val)
     {
       _value = val;

--- a/include/sqlpp11/data_types/text/wrap_operand.h
+++ b/include/sqlpp11/data_types/text/wrap_operand.h
@@ -26,10 +26,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sqlpp11/compat/cxx_std_ver.h>
+#include <sqlpp11/compat/sqlpp_cxx_std.h>
 
 #include <utility>
-#if CXX_STD_VER >= 201703L
+#if SQLPP_CXX_STD >= 201703L
 #include <string_view>
 #endif
 #include <sqlpp11/type_traits.h>
@@ -39,7 +39,7 @@ namespace sqlpp
 {
   struct text_operand;
 
-#if CXX_STD_VER >= 201703L
+#if SQLPP_CXX_STD >= 201703L
   using checked_type = std::string_view;
 #else
   using checked_type = std::string;

--- a/include/sqlpp11/data_types/text/wrap_operand.h
+++ b/include/sqlpp11/data_types/text/wrap_operand.h
@@ -26,8 +26,10 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <sqlpp11/compat/cxx_std_ver.h>
+
 #include <utility>
-#if __cplusplus >= 201703L
+#if CXX_STD_VER >= 201703L
 #include <string_view>
 #endif
 #include <sqlpp11/type_traits.h>
@@ -37,7 +39,7 @@ namespace sqlpp
 {
   struct text_operand;
 
-#if __cplusplus >= 201703L
+#if CXX_STD_VER >= 201703L
   using checked_type = std::string_view;
 #else
   using checked_type = std::string;

--- a/include/sqlpp11/result.h
+++ b/include/sqlpp11/result.h
@@ -26,7 +26,7 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sqlpp11/compat/cxx_std_ver.h>
+#include <sqlpp11/compat/sqlpp_cxx_std.h>
 
 #include <functional>
 #include <iterator>
@@ -83,7 +83,7 @@ namespace sqlpp
     class iterator
     {
     public:
-#if CXX_STD_VER >= 202002L
+#if SQLPP_CXX_STD >= 202002L
       using iterator_concept = std::input_iterator_tag;
 #else
       // LegacyInputIterator describes best our iterator's capabilities. However our iterator does not

--- a/include/sqlpp11/result.h
+++ b/include/sqlpp11/result.h
@@ -26,6 +26,8 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <sqlpp11/compat/cxx_std_ver.h>
+
 #include <functional>
 #include <iterator>
 #include <utility>
@@ -81,7 +83,7 @@ namespace sqlpp
     class iterator
     {
     public:
-#if __cplusplus >= 202002L
+#if CXX_STD_VER >= 202002L
       using iterator_concept = std::input_iterator_tag;
 #else
       // LegacyInputIterator describes best our iterator's capabilities. However our iterator does not

--- a/tests/core/serialize/Insert.cpp
+++ b/tests/core/serialize/Insert.cpp
@@ -23,7 +23,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sqlpp11/compat/cxx_std_ver.h>
+#include <sqlpp11/compat/sqlpp_cxx_std.h>
 
 #include "compare.h"
 #include "Sample.h"
@@ -49,7 +49,7 @@ int Insert(int, char* [])
           "INSERT INTO tab_bar (beta,gamma) VALUES('cheesecake'," + getTrue() + ")");
   compare(__LINE__, insert_into(bar).set(bar.beta = ::sqlpp::null, bar.gamma = true),
           "INSERT INTO tab_bar (beta,gamma) VALUES(NULL," + getTrue() + ")");
-#if CXX_STD_VER >= 201703L
+#if SQLPP_CXX_STD >= 201703L
   // string_view argument
   std::string_view cheeseCake = "cheesecake";
   compare(__LINE__, insert_into(bar).set(bar.beta = cheeseCake, bar.gamma = true),

--- a/tests/core/serialize/Insert.cpp
+++ b/tests/core/serialize/Insert.cpp
@@ -23,6 +23,8 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <sqlpp11/compat/cxx_std_ver.h>
+
 #include "compare.h"
 #include "Sample.h"
 #include <sqlpp11/sqlpp11.h>
@@ -47,7 +49,7 @@ int Insert(int, char* [])
           "INSERT INTO tab_bar (beta,gamma) VALUES('cheesecake'," + getTrue() + ")");
   compare(__LINE__, insert_into(bar).set(bar.beta = ::sqlpp::null, bar.gamma = true),
           "INSERT INTO tab_bar (beta,gamma) VALUES(NULL," + getTrue() + ")");
-#if __cplusplus >= 201703L
+#if CXX_STD_VER >= 201703L
   // string_view argument
   std::string_view cheeseCake = "cheesecake";
   compare(__LINE__, insert_into(bar).set(bar.beta = cheeseCake, bar.gamma = true),

--- a/tests/core/serialize/Where.cpp
+++ b/tests/core/serialize/Where.cpp
@@ -23,6 +23,8 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <sqlpp11/compat/cxx_std_ver.h>
+
 #include "compare.h"
 #include "Sample.h"
 #include <sqlpp11/sqlpp11.h>
@@ -68,7 +70,7 @@ int Where(int, char*[])
   compare(__LINE__, where(is_equal_to_or_null(bar.beta, ::sqlpp::value_or_null("SQL"))), " WHERE (tab_bar.beta='SQL')");
   compare(__LINE__, where(is_equal_to_or_null(bar.beta, ::sqlpp::value_or_null<sqlpp::text>(::sqlpp::null))),
           " WHERE tab_bar.beta IS NULL");
-#if __cplusplus >= 201703L
+#if CXX_STD_VER >= 201703L
   // string_view argument
   std::string_view sqlString = "SQL";
   compare(__LINE__, where(bar.beta == sqlString), " WHERE (tab_bar.beta='SQL')");

--- a/tests/core/serialize/Where.cpp
+++ b/tests/core/serialize/Where.cpp
@@ -23,7 +23,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sqlpp11/compat/cxx_std_ver.h>
+#include <sqlpp11/compat/sqlpp_cxx_std.h>
 
 #include "compare.h"
 #include "Sample.h"
@@ -70,7 +70,7 @@ int Where(int, char*[])
   compare(__LINE__, where(is_equal_to_or_null(bar.beta, ::sqlpp::value_or_null("SQL"))), " WHERE (tab_bar.beta='SQL')");
   compare(__LINE__, where(is_equal_to_or_null(bar.beta, ::sqlpp::value_or_null<sqlpp::text>(::sqlpp::null))),
           " WHERE tab_bar.beta IS NULL");
-#if CXX_STD_VER >= 201703L
+#if SQLPP_CXX_STD >= 201703L
   // string_view argument
   std::string_view sqlString = "SQL";
   compare(__LINE__, where(bar.beta == sqlString), " WHERE (tab_bar.beta='SQL')");

--- a/tests/core/usage/Insert.cpp
+++ b/tests/core/usage/Insert.cpp
@@ -23,13 +23,13 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <sqlpp11/compat/cxx_std_ver.h>
+#include <sqlpp11/compat/sqlpp_cxx_std.h>
 
 #include "MockDb.h"
 #include "Sample.h"
 #include "is_regular.h"
 #include <iostream>
-#if CXX_STD_VER >= 201703L
+#if SQLPP_CXX_STD >= 201703L
 #include <string_view>
 #endif
 #include <sqlpp11/functions.h>
@@ -111,7 +111,7 @@ int Insert(int, char*[])
   prepared_insert.params.delta = sqlpp::value_or_null(17);
   db(prepared_insert);
 
-#if CXX_STD_VER >= 201703L
+#if SQLPP_CXX_STD >= 201703L
   auto prepared_insert_sv = db.prepare(insert_into(t).set(t.gamma = parameter(t.gamma), t.delta = parameter(t.delta), t.beta = parameter(t.beta)));
   prepared_insert_sv.params.gamma = true;
   prepared_insert_sv.params.delta = 17;

--- a/tests/core/usage/Insert.cpp
+++ b/tests/core/usage/Insert.cpp
@@ -23,11 +23,13 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <sqlpp11/compat/cxx_std_ver.h>
+
 #include "MockDb.h"
 #include "Sample.h"
 #include "is_regular.h"
 #include <iostream>
-#if __cplusplus >= 201703L
+#if CXX_STD_VER >= 201703L
 #include <string_view>
 #endif
 #include <sqlpp11/functions.h>
@@ -109,7 +111,7 @@ int Insert(int, char*[])
   prepared_insert.params.delta = sqlpp::value_or_null(17);
   db(prepared_insert);
 
-#if __cplusplus >= 201703L
+#if CXX_STD_VER >= 201703L
   auto prepared_insert_sv = db.prepare(insert_into(t).set(t.gamma = parameter(t.gamma), t.delta = parameter(t.delta), t.beta = parameter(t.beta)));
   prepared_insert_sv.params.gamma = true;
   prepared_insert_sv.params.delta = 17;


### PR DESCRIPTION
If MSVC is run with the default options, the `__cplusplus` macro always has the value `199711L`, so sqlpp11's code that relies on that macro detects incorrectly the C++ standard version.

The proper way to detect the C++ standard version is first to check for the `_MSVC_LANG` macro and if it is present, use its value as the C++ standard version, otherwise use `__cplusplus`.
For details see [/Zc:__cplusplus](https://learn.microsoft.com/en-us/cpp/build/reference/zc-cplusplus?view=msvc-170)

We already use this approach in `compat/make_unique.h`, by defining the custom macro `CXX_STD_VER`

This PR changes the code globally to use that custom macro `CXX_STD_VER`.
The PR was built and tested with
```
cmake -B build -DBUILD_POSTGRESQL_CONNECTOR=ON -DBUILD_SQLITE3_CONNECTOR=ON -DBUILD_MYSQL_CONNECTOR=ON -DBUILD_TESTING=ON -DUSE_SYSTEM_DATE=ON -DDEPENDENCY_CHECK=ON
cmake --build build
cd build
ctest
```