### PR TITLE
Add argumentless overload for get_sql_name()

### DIFF
--- a/include/sqlpp11/functions.h
+++ b/include/sqlpp11/functions.h
@@ -131,8 +131,14 @@ namespace sqlpp
   }
 
   template <typename T>
-  constexpr const char* get_sql_name(const T& /*unused*/)
+  constexpr const char* get_sql_name()
   {
     return name_of<T>::template char_ptr<void>();
+  }
+
+  template <typename T>
+  constexpr const char* get_sql_name(const T& /*unused*/)
+  {
+    return get_sql_name<T>();
   }
 }  // namespace sqlpp


### PR DESCRIPTION
Convenience function that comes handy with template metaprogramming: no need to create an object of the type whose SQL name we desire to use.

Also works with non-default constructible objects.