### PR TITLE
Enable execute() to run prepared_statements for all connectors

### DIFF
--- a/tests/core/usage/MockDb.h
+++ b/tests/core/usage/MockDb.h
@@ -137,15 +137,29 @@ struct MockDb : public sqlpp::connection
   }
 
   template <
-      typename Statement,
-      typename Enable = typename std::enable_if<not std::is_convertible<Statement, std::string>::value, void>::type>
-  size_t execute(const Statement& x)
+      typename Execute,
+      typename std::enable_if<not std::is_convertible<Execute, std::string>::value 
+                              and not sqlpp::is_prepared_statement_t<Execute>::value, int>::type = 0>
+  size_t execute(const Execute& x)
   {
+    static_assert(not sqlpp::is_select_t<Execute>::value, "argument must not be a select statement - use operator() instead");
+
     _serializer_context_t context;
     serialize(x, context);
     std::cout << "Running execute call with\n" << context.str() << std::endl;
     return execute(context.str());
   }
+
+  template <
+      typename Execute,
+      typename std::enable_if<sqlpp::is_prepared_statement_t<Execute>::value, int>::type = 0>
+  size_t execute(const Execute& x)
+  {
+    static_assert(not sqlpp::is_select_t<Execute>::value, "argument must not be a select statement - use operator() instead");
+    
+    operator()(x);
+    return 0;
+  }  
 
   template <typename Insert>
   size_t insert(const Insert& x)
@@ -345,15 +359,29 @@ struct MockSizeDb : public sqlpp::connection
   }
 
   template <
-      typename Statement,
-      typename Enable = typename std::enable_if<not std::is_convertible<Statement, std::string>::value, void>::type>
-  size_t execute(const Statement& x)
+      typename Execute,
+      typename std::enable_if<not std::is_convertible<Execute, std::string>::value 
+                              and not sqlpp::is_prepared_statement_t<Execute>::value, int>::type = 0>
+  size_t execute(const Execute& x)
   {
+    static_assert(not sqlpp::is_select_t<Execute>::value, "argument must not be a select statement - use operator() instead");
+
     _serializer_context_t context;
     serialize(x, context);
     std::cout << "Running execute call with\n" << context.str() << std::endl;
     return execute(context.str());
   }
+
+  template <
+      typename Execute,
+      typename std::enable_if<sqlpp::is_prepared_statement_t<Execute>::value, int>::type = 0>
+  size_t execute(const Execute& x)
+  {
+    static_assert(not sqlpp::is_select_t<Execute>::value, "argument must not be a select statement - use operator() instead");
+    
+    operator()(x);
+    return 0;
+  }  
 
   template <typename Insert>
   size_t insert(const Insert& x)

--- a/tests/mysql/usage/Execute.cpp
+++ b/tests/mysql/usage/Execute.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024, Roland Bock
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Sample.h"
+#include "make_test_connection.h"
+
+#include <sqlpp11/alias_provider.h>
+#include <sqlpp11/parameter.h>
+#include <sqlpp11/update.h>
+#include <sqlpp11/verbatim.h>
+#include <sqlpp11/mysql/connection.h>
+
+#include <iostream>
+
+namespace sql = sqlpp::mysql;
+
+int Execute(int, char*[])
+{
+  sql::connection db = sql::make_test_connection();
+
+  // execute supports single statements.
+  db.execute(R"(SELECT 1)");
+
+  // execute throws an exception if multiple statements are passed in the string.
+  try
+  {
+    db.execute(R"(SELECT 1; SELECT 2)");
+  }
+  catch (const sqlpp::exception& e)
+  {
+    const auto message = std::string(e.what());
+    if (message.find("Cannot execute multi-statements") == message.npos)
+    {
+      std::cerr << "Unexpected exception for multi-statement: " << message;
+      return 1;
+    }
+  }
+
+  // execute supports running a prepared statement
+  const auto tab = test::TabBar{};
+
+  db.execute(R"(CREATE TABLE tab_bar (
+                	alpha bigint AUTO_INCREMENT,
+                	beta varchar(255) NULL DEFAULT "",
+                	gamma bool NOT NULL,
+                	delta int);
+              )");
+
+  auto u = sqlpp::update(tab)
+              .set(tab.delta = sqlpp::parameter(tab.delta))
+              .where(sqlpp::verbatim<sqlpp::unsigned_integral>("ROWID")
+                    == sqlpp::parameter(sqlpp::unsigned_integral(), sqlpp::alias::i));
+
+  auto u_stmnt = db.prepare(u);
+  u_stmnt.params.delta = 42;
+  u_stmnt.params.i = 69u;
+
+  db.execute(u_stmnt);
+
+  return 0;
+}

--- a/tests/postgresql/usage/Execute.cpp
+++ b/tests/postgresql/usage/Execute.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2024, Roland Bock
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "Sample.h"
+#include "make_test_connection.h"
+
+#include <sqlpp11/alias_provider.h>
+#include <sqlpp11/parameter.h>
+#include <sqlpp11/update.h>
+#include <sqlpp11/verbatim.h>
+#include <sqlpp11/postgresql/connection.h>
+
+#include <iostream>
+
+namespace sql = sqlpp::postgresql;
+
+int Execute(int, char*[])
+{
+  sql::connection db = sql::make_test_connection();
+
+  // execute supports single statements.
+  db.execute(R"(SELECT 1)");
+
+  // execute throws an exception if multiple statements are passed in the string.
+  try
+  {
+    db.execute(R"(SELECT 1; SELECT 2)");
+  }
+  catch (const sqlpp::exception& e)
+  {
+    const auto message = std::string(e.what());
+    if (message.find("Cannot execute multi-statements") == message.npos)
+    {
+      std::cerr << "Unexpected exception for multi-statement: " << message;
+      return 1;
+    }
+  }
+
+  // execute supports running a prepared statement
+  const auto tab = test::TabBar{};
+
+  db.execute(R"(CREATE TABLE tab_bar (
+                	alpha bigint AUTO_INCREMENT,
+                	beta varchar(255) NULL DEFAULT "",
+                	gamma bool NOT NULL,
+                	delta int);
+              )");
+
+  auto u = sqlpp::update(tab)
+              .set(tab.delta = sqlpp::parameter(tab.delta))
+              .where(sqlpp::verbatim<sqlpp::unsigned_integral>("ROWID")
+                    == sqlpp::parameter(sqlpp::unsigned_integral(), sqlpp::alias::i));
+
+  auto u_stmnt = db.prepare(u);
+  u_stmnt.params.delta = 42;
+  u_stmnt.params.i = 69u;
+
+  db.execute(u_stmnt);
+
+  return 0;
+}


### PR DESCRIPTION
I am absolutely not sure about what applies to PostgreSQL and MySQL in terms of limitation to one query at a time or return value, but I hope that this is in any case a good baseline. 

I have taken the liberty to modify the return type of `execute()` for MySql from `void` to `size_t` so that it is in sync with other connectors.