### PR TITLE
Fix find_package_handle_standard_args

### DIFF
--- a/cmake/modules/FindMariaDB.cmake
+++ b/cmake/modules/FindMariaDB.cmake
@@ -52,6 +52,7 @@ endif()
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
     MariaDB
+    DEFAULT_MSG
     MariaDB_INCLUDE_DIR
     MariaDB_LIBRARY
 )

--- a/cmake/modules/FindMySQL.cmake
+++ b/cmake/modules/FindMySQL.cmake
@@ -56,6 +56,7 @@ endif()
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
     MySQL
+    DEFAULT_MSG
     MySQL_INCLUDE_DIR
     MySQL_LIBRARY
 )


### PR DESCRIPTION
Fixes first var being misunderstood as custom message.
Fixes actually checking the first var.

~~~
CMake Error at E:/vcpkg/downloads/tools/cmake-3.29.2-windows/cmake-3.29.2-windows-i386/share/cmake-3.29/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  MySQL_INCLUDE_DIR (missing: MySQL_LIBRARY)
~~~