### PR TITLE
Update vcpkg section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ git clone https://github.com/Microsoft/vcpkg.git
 cd vcpkg
 ./bootstrap-vcpkg.sh
 ./vcpkg integrate install
-vcpkg install sqlpp11[<database>]
+./vcpkg install 'sqlpp11[mysql]' # or other database feature
 ```
 
 The sqlpp11 port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.

--- a/README.md
+++ b/README.md
@@ -194,21 +194,16 @@ Some connectors can be installed with the formula. See `brew info marvin182/zapf
 __Build via vcpkg:__
 
 You can download and install sqlpp11 using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
-   
+
 ```bash
 git clone https://github.com/Microsoft/vcpkg.git
 cd vcpkg
 ./bootstrap-vcpkg.sh
 ./vcpkg integrate install
-vcpkg install sqlpp11
+vcpkg install sqlpp11[<database>]
 ```
-    
+
 The sqlpp11 port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
-
-The following connector libraries for sqlpp11 are maintained as a separate package in vcpkg:
-
-  * [sqlpp11-connector-sqlite3](https://github.com/microsoft/vcpkg/tree/master/ports/sqlpp11-connector-sqlite3) 
-  * [sqlpp11-connector-mysql](https://github.com/microsoft/vcpkg/tree/master/ports/sqlpp11-connector-mysql)
 
 Basic usage:
 -------------


### PR DESCRIPTION
Don't advertise the connector ports. (Legacy.)
Indicate that a database feature must be selected.