### PR TITLE
Support binding results and parameters of type time_of_day with SQLite3

### DIFF
--- a/include/sqlpp11/sqlite3/bind_result.h
+++ b/include/sqlpp11/sqlite3/bind_result.h
@@ -204,6 +204,29 @@ namespace sqlpp
         }
       }
 
+      void _bind_time_of_day_result(size_t index, ::std::chrono::microseconds* value, bool* is_null)
+      {
+        if (_handle->debug)
+          std::cerr << "Sqlite3 debug: binding time_of_day result at index: " << index << std::endl;
+
+        *value = {};
+        *is_null = sqlite3_column_type(_handle->sqlite_statement, static_cast<int>(index)) == SQLITE_NULL;
+        if (*is_null)
+        {
+          return;
+        }
+
+        const auto time_string =
+            reinterpret_cast<const char*>(sqlite3_column_text(_handle->sqlite_statement, static_cast<int>(index)));
+        if (_handle->debug)
+          std::cerr << "Sqlite3 debug: time string: " << time_string << std::endl;
+        if (::sqlpp::detail::parse_time_of_day(*value, time_string) == false)
+        {
+          if (_handle->debug)
+            std::cerr << "Sqlite3 debug: invalid time result: " << time_string << std::endl;
+        }
+      }
+
     private:
       bool next_impl()
       {

--- a/include/sqlpp11/sqlite3/prepared_statement.h
+++ b/include/sqlpp11/sqlite3/prepared_statement.h
@@ -256,7 +256,7 @@ namespace sqlpp
         int result;
         if (not is_null)
         {
-          const auto time = ::date::make_time(::sqlpp::chrono::floor<::std::chrono::microseconds>(*value));
+          const auto time = ::date::make_time(*value);
           std::ostringstream os;  // gcc-4.9 does not support auto os = std::ostringstream{};
           os << time;
           const auto text = os.str();

--- a/include/sqlpp11/sqlite3/prepared_statement.h
+++ b/include/sqlpp11/sqlite3/prepared_statement.h
@@ -246,6 +246,27 @@ namespace sqlpp
           result = sqlite3_bind_null(_handle->sqlite_statement, static_cast<int>(index + 1));
         detail::check_bind_result(result, "blob");
       }
+
+      void _bind_time_of_day_parameter(size_t index, const ::std::chrono::microseconds* value, bool is_null)
+      {
+        if (_handle->debug)
+          std::cerr << "Sqlite3 debug: binding time_of_day parameter "
+                    << " at index: " << index << ", being " << (is_null ? "" : "not ") << "null" << std::endl;
+
+        int result;
+        if (not is_null)
+        {
+          const auto time = ::date::make_time(::sqlpp::chrono::floor<::std::chrono::microseconds>(*value));
+          std::ostringstream os;  // gcc-4.9 does not support auto os = std::ostringstream{};
+          os << time;
+          const auto text = os.str();
+          result = sqlite3_bind_text(_handle->sqlite_statement, static_cast<int>(index + 1), text.data(),
+                                     static_cast<int>(text.size()), SQLITE_TRANSIENT);
+        }
+        else
+          result = sqlite3_bind_null(_handle->sqlite_statement, static_cast<int>(index + 1));
+        detail::check_bind_result(result, "date");
+      }
     };
   }  // namespace sqlite3
 }  // namespace sqlpp

--- a/tests/sqlite3/usage/TabSample.h
+++ b/tests/sqlite3/usage/TabSample.h
@@ -222,9 +222,31 @@ namespace TabDateTime_
     };
     using _traits = sqlpp::make_traits<sqlpp::time_point, sqlpp::tag::can_be_null>;
   };
+  struct ColTimeOfDay
+  {
+    struct _alias_t
+    {
+      static constexpr const char _literal[] = "col_time_of_day";
+      using _name_t = sqlpp::make_char_sequence<sizeof(_literal), _literal>;
+      template <typename T>
+      struct _member_t
+      {
+        T colTimeOfDay;
+        T& operator()()
+        {
+          return colTimeOfDay;
+        }
+        const T& operator()() const
+        {
+          return colTimeOfDay;
+        }
+      };
+    };
+    using _traits = sqlpp::make_traits<sqlpp::time_of_day, sqlpp::tag::can_be_null>;
+  };
 }
 
-struct TabDateTime : sqlpp::table_t<TabDateTime, TabDateTime_::ColDayPoint, TabDateTime_::ColTimePoint>
+struct TabDateTime : sqlpp::table_t<TabDateTime, TabDateTime_::ColDayPoint, TabDateTime_::ColTimePoint, TabDateTime_::ColTimeOfDay>
 {
   struct _alias_t
   {


### PR DESCRIPTION
While testing with sqlite3 I got a compile-time error: "`class sqlpp::sqlite3::bind_result_t` has no member named `_bind_time_of_day_result`" and as I saw no reason to not have it, I've added it and it seems to work.

If there's anything else  to do, please let me know. C:

-Jonas