### PR TITLE
Add SQL functions CURRENT_DATE, CURRENT_TIME and CURRENT_TIMESTAMP

### DIFF
--- a/include/sqlpp11/current_date.h
+++ b/include/sqlpp11/current_date.h
@@ -1,0 +1,84 @@
+#pragma once
+
+/*
+ * Copyright (c) 2013-2015, Roland Bock
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *   Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *   Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sqlpp11/char_sequence.h>
+#include <sqlpp11/data_types/day_point/data_type.h>
+
+namespace sqlpp
+{
+  struct current_date_alias_t
+  {
+    struct _alias_t
+    {
+      static constexpr const char _literal[] = "current_date_";
+      using _name_t = sqlpp::make_char_sequence<sizeof(_literal), _literal>;
+      template <typename T>
+      struct _member_t
+      {
+        T current_date;
+        T& operator()()
+        {
+          return current_date;
+        }
+        const T& operator()() const
+        {
+          return current_date;
+        }
+      };
+    };
+  };
+
+  struct current_date_t : public expression_operators<current_date_t, day_point>, public alias_operators<current_date_t>
+  {
+    using _traits = make_traits<day_point, tag::is_expression, tag::is_selectable>;
+
+    using _nodes = detail::type_vector<>;
+    using _can_be_null = std::false_type;
+
+    using _auto_alias_t = current_date_alias_t;
+
+    constexpr current_date_t()
+    {
+    }
+
+    current_date_t(const current_date_t&) = default;
+    current_date_t(current_date_t&&) = default;
+    current_date_t& operator=(const current_date_t&) = default;
+    current_date_t& operator=(current_date_t&&) = default;
+    ~current_date_t() = default;
+  };
+
+  template <typename Context>
+  Context& serialize(const current_date_t& t, Context& context)
+  {
+    context << "CURRENT_DATE";
+    return context;
+  }
+
+  constexpr current_date_t current_date{};
+}  // namespace sqlpp

--- a/include/sqlpp11/current_date.h
+++ b/include/sqlpp11/current_date.h
@@ -74,7 +74,7 @@ namespace sqlpp
   };
 
   template <typename Context>
-  Context& serialize(const current_date_t& t, Context& context)
+  Context& serialize(const current_date_t&, Context& context)
   {
     context << "CURRENT_DATE";
     return context;

--- a/include/sqlpp11/current_date.h
+++ b/include/sqlpp11/current_date.h
@@ -35,32 +35,7 @@ namespace sqlpp
   {
     using _traits = make_traits<day_point, tag::is_expression, tag::is_selectable>;
 
-    using _nodes = detail::type_vector<>;
-    using _can_be_null = std::false_type;
-
-    struct _alias_t
-    {
-      static constexpr const char _literal[] = "current_date_";
-      using _name_t = sqlpp::make_char_sequence<sizeof(_literal), _literal>;
-      template <typename T>
-      struct _member_t
-      {
-        T current_date;
-        T& operator()()
-        {
-          return current_date;
-        }
-        const T& operator()() const
-        {
-          return current_date;
-        }
-      };
-    };
-
-    constexpr current_date_t()
-    {
-    }
-
+    constexpr current_date_t() = default;
     current_date_t(const current_date_t&) = default;
     current_date_t(current_date_t&&) = default;
     current_date_t& operator=(const current_date_t&) = default;

--- a/include/sqlpp11/current_date.h
+++ b/include/sqlpp11/current_date.h
@@ -31,8 +31,13 @@
 
 namespace sqlpp
 {
-  struct current_date_alias_t
+  struct current_date_t : public expression_operators<current_date_t, day_point>, public alias_operators<current_date_t>
   {
+    using _traits = make_traits<day_point, tag::is_expression, tag::is_selectable>;
+
+    using _nodes = detail::type_vector<>;
+    using _can_be_null = std::false_type;
+
     struct _alias_t
     {
       static constexpr const char _literal[] = "current_date_";
@@ -51,16 +56,6 @@ namespace sqlpp
         }
       };
     };
-  };
-
-  struct current_date_t : public expression_operators<current_date_t, day_point>, public alias_operators<current_date_t>
-  {
-    using _traits = make_traits<day_point, tag::is_expression, tag::is_selectable>;
-
-    using _nodes = detail::type_vector<>;
-    using _can_be_null = std::false_type;
-
-    using _auto_alias_t = current_date_alias_t;
 
     constexpr current_date_t()
     {

--- a/include/sqlpp11/current_time.h
+++ b/include/sqlpp11/current_time.h
@@ -31,8 +31,13 @@
 
 namespace sqlpp
 {
-  struct current_time_alias_t
+  struct current_time_t : public expression_operators<current_time_t, time_of_day>, public alias_operators<current_time_t>
   {
+    using _traits = make_traits<time_of_day, tag::is_expression, tag::is_selectable>;
+
+    using _nodes = detail::type_vector<>;
+    using _can_be_null = std::false_type;
+
     struct _alias_t
     {
       static constexpr const char _literal[] = "current_time_";
@@ -51,16 +56,6 @@ namespace sqlpp
         }
       };
     };
-  };
-
-  struct current_time_t : public expression_operators<current_time_t, time_of_day>, public alias_operators<current_time_t>
-  {
-    using _traits = make_traits<time_of_day, tag::is_expression, tag::is_selectable>;
-
-    using _nodes = detail::type_vector<>;
-    using _can_be_null = std::false_type;
-
-    using _auto_alias_t = current_time_alias_t;
 
     constexpr current_time_t()
     {

--- a/include/sqlpp11/current_time.h
+++ b/include/sqlpp11/current_time.h
@@ -35,32 +35,7 @@ namespace sqlpp
   {
     using _traits = make_traits<time_of_day, tag::is_expression, tag::is_selectable>;
 
-    using _nodes = detail::type_vector<>;
-    using _can_be_null = std::false_type;
-
-    struct _alias_t
-    {
-      static constexpr const char _literal[] = "current_time_";
-      using _name_t = sqlpp::make_char_sequence<sizeof(_literal), _literal>;
-      template <typename T>
-      struct _member_t
-      {
-        T current_time;
-        T& operator()()
-        {
-          return current_time;
-        }
-        const T& operator()() const
-        {
-          return current_time;
-        }
-      };
-    };
-
-    constexpr current_time_t()
-    {
-    }
-
+    constexpr current_time_t() = default;
     current_time_t(const current_time_t&) = default;
     current_time_t(current_time_t&&) = default;
     current_time_t& operator=(const current_time_t&) = default;

--- a/include/sqlpp11/current_time.h
+++ b/include/sqlpp11/current_time.h
@@ -74,7 +74,7 @@ namespace sqlpp
   };
 
   template <typename Context>
-  Context& serialize(const current_time_t& t, Context& context)
+  Context& serialize(const current_time_t&, Context& context)
   {
     context << "CURRENT_TIME";
     return context;

--- a/include/sqlpp11/current_time.h
+++ b/include/sqlpp11/current_time.h
@@ -1,0 +1,84 @@
+#pragma once
+
+/*
+ * Copyright (c) 2013-2015, Roland Bock
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *   Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *   Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sqlpp11/char_sequence.h>
+#include <sqlpp11/data_types/time_of_day/data_type.h>
+
+namespace sqlpp
+{
+  struct current_time_alias_t
+  {
+    struct _alias_t
+    {
+      static constexpr const char _literal[] = "current_time_";
+      using _name_t = sqlpp::make_char_sequence<sizeof(_literal), _literal>;
+      template <typename T>
+      struct _member_t
+      {
+        T current_time;
+        T& operator()()
+        {
+          return current_time;
+        }
+        const T& operator()() const
+        {
+          return current_time;
+        }
+      };
+    };
+  };
+
+  struct current_time_t : public expression_operators<current_time_t, time_of_day>, public alias_operators<current_time_t>
+  {
+    using _traits = make_traits<time_of_day, tag::is_expression, tag::is_selectable>;
+
+    using _nodes = detail::type_vector<>;
+    using _can_be_null = std::false_type;
+
+    using _auto_alias_t = current_time_alias_t;
+
+    constexpr current_time_t()
+    {
+    }
+
+    current_time_t(const current_time_t&) = default;
+    current_time_t(current_time_t&&) = default;
+    current_time_t& operator=(const current_time_t&) = default;
+    current_time_t& operator=(current_time_t&&) = default;
+    ~current_time_t() = default;
+  };
+
+  template <typename Context>
+  Context& serialize(const current_time_t& t, Context& context)
+  {
+    context << "CURRENT_TIME";
+    return context;
+  }
+
+  constexpr current_time_t current_time{};
+}  // namespace sqlpp

--- a/include/sqlpp11/current_timestamp.h
+++ b/include/sqlpp11/current_timestamp.h
@@ -74,7 +74,7 @@ namespace sqlpp
   };
 
   template <typename Context>
-  Context& serialize(const current_timestamp_t& t, Context& context)
+  Context& serialize(const current_timestamp_t&, Context& context)
   {
     context << "CURRENT_TIMESTAMP";
     return context;

--- a/include/sqlpp11/current_timestamp.h
+++ b/include/sqlpp11/current_timestamp.h
@@ -35,32 +35,7 @@ namespace sqlpp
   {
     using _traits = make_traits<time_point, tag::is_expression, tag::is_selectable>;
 
-    using _nodes = detail::type_vector<>;
-    using _can_be_null = std::false_type;
-
-    struct _alias_t
-    {
-      static constexpr const char _literal[] = "current_timestamp_";
-      using _name_t = sqlpp::make_char_sequence<sizeof(_literal), _literal>;
-      template <typename T>
-      struct _member_t
-      {
-        T current_timestamp;
-        T& operator()()
-        {
-          return current_timestamp;
-        }
-        const T& operator()() const
-        {
-          return current_timestamp;
-        }
-      };
-    };
-
-    constexpr current_timestamp_t()
-    {
-    }
-
+    constexpr current_timestamp_t() = default;
     current_timestamp_t(const current_timestamp_t&) = default;
     current_timestamp_t(current_timestamp_t&&) = default;
     current_timestamp_t& operator=(const current_timestamp_t&) = default;

--- a/include/sqlpp11/current_timestamp.h
+++ b/include/sqlpp11/current_timestamp.h
@@ -1,0 +1,84 @@
+#pragma once
+
+/*
+ * Copyright (c) 2013-2015, Roland Bock
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *   Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *   Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <sqlpp11/char_sequence.h>
+#include <sqlpp11/data_types/time_point/data_type.h>
+
+namespace sqlpp
+{
+  struct current_timestamp_alias_t
+  {
+    struct _alias_t
+    {
+      static constexpr const char _literal[] = "current_timestamp_";
+      using _name_t = sqlpp::make_char_sequence<sizeof(_literal), _literal>;
+      template <typename T>
+      struct _member_t
+      {
+        T current_timestamp;
+        T& operator()()
+        {
+          return current_timestamp;
+        }
+        const T& operator()() const
+        {
+          return current_timestamp;
+        }
+      };
+    };
+  };
+
+  struct current_timestamp_t : public expression_operators<current_timestamp_t, time_point>, public alias_operators<current_timestamp_t>
+  {
+    using _traits = make_traits<time_point, tag::is_expression, tag::is_selectable>;
+
+    using _nodes = detail::type_vector<>;
+    using _can_be_null = std::false_type;
+
+    using _auto_alias_t = current_timestamp_alias_t;
+
+    constexpr current_timestamp_t()
+    {
+    }
+
+    current_timestamp_t(const current_timestamp_t&) = default;
+    current_timestamp_t(current_timestamp_t&&) = default;
+    current_timestamp_t& operator=(const current_timestamp_t&) = default;
+    current_timestamp_t& operator=(current_timestamp_t&&) = default;
+    ~current_timestamp_t() = default;
+  };
+
+  template <typename Context>
+  Context& serialize(const current_timestamp_t& t, Context& context)
+  {
+    context << "CURRENT_TIMESTAMP";
+    return context;
+  }
+
+  constexpr current_timestamp_t current_timestamp{};
+}  // namespace sqlpp

--- a/include/sqlpp11/current_timestamp.h
+++ b/include/sqlpp11/current_timestamp.h
@@ -31,8 +31,13 @@
 
 namespace sqlpp
 {
-  struct current_timestamp_alias_t
+  struct current_timestamp_t : public expression_operators<current_timestamp_t, time_point>, public alias_operators<current_timestamp_t>
   {
+    using _traits = make_traits<time_point, tag::is_expression, tag::is_selectable>;
+
+    using _nodes = detail::type_vector<>;
+    using _can_be_null = std::false_type;
+
     struct _alias_t
     {
       static constexpr const char _literal[] = "current_timestamp_";
@@ -51,16 +56,6 @@ namespace sqlpp
         }
       };
     };
-  };
-
-  struct current_timestamp_t : public expression_operators<current_timestamp_t, time_point>, public alias_operators<current_timestamp_t>
-  {
-    using _traits = make_traits<time_point, tag::is_expression, tag::is_selectable>;
-
-    using _nodes = detail::type_vector<>;
-    using _can_be_null = std::false_type;
-
-    using _auto_alias_t = current_timestamp_alias_t;
 
     constexpr current_timestamp_t()
     {

--- a/include/sqlpp11/functions.h
+++ b/include/sqlpp11/functions.h
@@ -50,6 +50,9 @@
 #include <sqlpp11/value_or_null.h>
 #include <sqlpp11/is_equal_to_or_null.h>
 #include <sqlpp11/eval.h>
+#include <sqlpp11/current_timestamp.h>
+#include <sqlpp11/current_date.h>
+#include <sqlpp11/current_time.h>
 
 namespace sqlpp
 {

--- a/tests/core/serialize/CMakeLists.txt
+++ b/tests/core/serialize/CMakeLists.txt
@@ -51,6 +51,9 @@ set(test_files
     Upper.cpp
     Where.cpp
     ParameterizedVerbatim.cpp
+    CurrentTimestamp.cpp
+    CurrentTime.cpp
+    CurrentDate.cpp
 )
 
 create_test_sourcelist(test_sources test_serializer_main.cpp ${test_files})

--- a/tests/core/serialize/CurrentDate.cpp
+++ b/tests/core/serialize/CurrentDate.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024, Roland Bock
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "compare.h"
+#include <sqlpp11/sqlpp11.h>
+
+int CurrentDate(int, char* [])
+{
+  compare(__LINE__, sqlpp::current_date, "CURRENT_DATE");
+
+  return 0;
+}

--- a/tests/core/serialize/CurrentTime.cpp
+++ b/tests/core/serialize/CurrentTime.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024, Roland Bock
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "compare.h"
+#include <sqlpp11/sqlpp11.h>
+
+int CurrentTime(int, char* [])
+{
+  compare(__LINE__, sqlpp::current_time, "CURRENT_TIME");
+
+  return 0;
+}

--- a/tests/core/serialize/CurrentTimestamp.cpp
+++ b/tests/core/serialize/CurrentTimestamp.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024, Roland Bock
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "compare.h"
+#include <sqlpp11/sqlpp11.h>
+
+int CurrentTimestamp(int, char* [])
+{
+  compare(__LINE__, sqlpp::current_timestamp, "CURRENT_TIMESTAMP");
+
+  return 0;
+}


### PR DESCRIPTION
I guess you can also just use std::chrono instead but with those functions (which are also standardized) it might feel more like SQL.

-Jonas