### PR TITLE
[-] postgresql::dynamic_queries assert passed connections properly

### DIFF
--- a/include/sqlpp11/mysql/remove.h
+++ b/include/sqlpp11/mysql/remove.h
@@ -52,7 +52,7 @@ namespace sqlpp
     template <typename Database>
     auto dynamic_remove(const Database& /*unused*/) -> decltype(blank_remove_t<Database>())
     {
-      static_assert(std::is_base_of<connection, Database>::value, "Invalid database parameter");
+      static_assert(std::is_base_of<connection_base, Database>::value, "Invalid database parameter");
       return {blank_remove_t<Database>()};
     }
 
@@ -60,7 +60,7 @@ namespace sqlpp
     auto dynamic_remove_from(const Database& /*unused*/, Table table)
         -> decltype(blank_remove_t<Database>().from(table))
     {
-      static_assert(std::is_base_of<connection, Database>::value, "Invalid database parameter");
+      static_assert(std::is_base_of<connection_base, Database>::value, "Invalid database parameter");
       return {blank_remove_t<Database>().from(table)};
     }
   }  // namespace mysql

--- a/include/sqlpp11/mysql/update.h
+++ b/include/sqlpp11/mysql/update.h
@@ -53,7 +53,7 @@ namespace sqlpp
     constexpr auto dynamic_update(const Database& /*unused*/, Table table)
         -> decltype(blank_update_t<Database>().single_table(table))
     {
-      static_assert(std::is_base_of<connection, Database>::value, "Invalid database parameter");
+      static_assert(std::is_base_of<connection_base, Database>::value, "Invalid database parameter");
       return {blank_update_t<Database>().single_table(table)};
     }
   }  // namespace mysql

--- a/include/sqlpp11/postgresql/insert.h
+++ b/include/sqlpp11/postgresql/insert.h
@@ -52,14 +52,14 @@ namespace sqlpp
     template <typename Database>
     constexpr auto dynamic_insert(const Database&) -> decltype(blank_insert_t<Database>())
     {
-      static_assert(std::is_base_of<connection, Database>::value, "Invalid database parameter");
+      static_assert(std::is_base_of<connection_base, Database>::value, "Invalid database parameter");
       return {blank_insert_t<Database>()};
     }
 
     template <typename Database, typename Table>
     constexpr auto dynamic_insert_into(const Database&, Table table) -> decltype(blank_insert_t<Database>().into(table))
     {
-      static_assert(std::is_base_of<connection, Database>::value, "Invalid database parameter");
+      static_assert(std::is_base_of<connection_base, Database>::value, "Invalid database parameter");
       return {blank_insert_t<Database>().into(table)};
     }
   }  // namespace postgresql

--- a/include/sqlpp11/postgresql/remove.h
+++ b/include/sqlpp11/postgresql/remove.h
@@ -50,7 +50,7 @@ namespace sqlpp
     template <typename Database>
     auto dynamic_remove(const Database& /*unused*/) -> decltype(blank_remove_t<Database>())
     {
-      static_assert(std::is_base_of<connection, Database>::value, "Invalid database parameter");
+      static_assert(std::is_base_of<connection_base, Database>::value, "Invalid database parameter");
       return {blank_remove_t<Database>()};
     }
 
@@ -58,7 +58,7 @@ namespace sqlpp
     auto dynamic_remove_from(const Database& /*unused*/, Table table)
         -> decltype(blank_remove_t<Database>().from(table))
     {
-      static_assert(std::is_base_of<connection, Database>::value, "Invalid database parameter");
+      static_assert(std::is_base_of<connection_base, Database>::value, "Invalid database parameter");
       return {blank_remove_t<Database>().from(table)};
     }
   }  // namespace postgresql

--- a/include/sqlpp11/postgresql/returning.h
+++ b/include/sqlpp11/postgresql/returning.h
@@ -163,7 +163,7 @@ namespace sqlpp
                         "at least one returnable expression (e.g. a column) is required in returning");
           static_assert(decltype(_check_args(columns...))::value,
                         "at least one argument is not a returnable expression in returning()");
-          static_assert(std::is_base_of<connection, Database>::value, "Invalid database parameter");
+          static_assert(std::is_base_of<connection_base, Database>::value, "Invalid database parameter");
           return {static_cast<const derived_statement_t<Policies>&>(*this),
                   typename dynamic_returning_column_list<_database_t>::_data_t{columns...}};
         }

--- a/include/sqlpp11/postgresql/update.h
+++ b/include/sqlpp11/postgresql/update.h
@@ -47,7 +47,7 @@ namespace sqlpp
     constexpr auto dynamic_update(const Database&, Table table)
         -> decltype(blank_update_t<Database>().single_table(table))
     {
-      static_assert(std::is_base_of<connection, Database>::value, "Invalid database parameter");
+      static_assert(std::is_base_of<connection_base, Database>::value, "Invalid database parameter");
       return {blank_update_t<Database>().single_table(table)};
     }
   }


### PR DESCRIPTION
Static assert fix regarding connection type.
Since now `pooled_connections` are allowed to process postgres-dynamic-queries.
related to issue https://github.com/rbock/sqlpp11/issues/612